### PR TITLE
fixed issue in view_polycam_data.py #2

### DIFF
--- a/simplecv/data/polycam.py
+++ b/simplecv/data/polycam.py
@@ -226,11 +226,13 @@ def validate_zip(zip_path: Path) -> bool:
 
 
 def find_keyframes_dir(extract_dir: Path) -> Path | None:
+    # Skip __MACOSX metadata cache
     for path in extract_dir.rglob("*"):
+        if "__MACOSX" in path.parts:
+            continue
         if path.is_dir() and path.name == "keyframes":
             return path
     return None
-
 
 def load_polycam_data(polycam_zip_or_directory_path: Path) -> PolycamDataset:
     extract_dir: Path = polycam_zip_or_directory_path.with_suffix("")


### PR DESCRIPTION
Potential fix to #2.

I have tested the code by running, and below is the result

```
$ python tools/view_polycam_data.py --polycam-zip-path kornia-slam/data/example-room-scan-poly.zip
```

<img src="https://github.com/user-attachments/assets/253a9ab8-008b-404f-bc58-97ce47a52794">

```
(kornia-slam) somusan@somusan:~/.../kornia-slam
$ ls data/example-room-scan-poly
example-room-scan-poly  __MACOSX
```
