### PR TITLE
[simplecv] Emphasize jaxtyping type annotations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,20 +20,21 @@ world_points = world_T_cam @ cam_points  # camera → world
 ```
 Both directions are stored in `Extrinsics` dataclass and computed automatically.
 
-### Type Safety with JAXTyping
-All arrays use shape-annotated types:
+### Array Type Annotations with JAXTyping
+Every array must specify both dtype and shape using jaxtyping, and variables should be annotated at assignment time:
 ```python
-from jaxtyping import Float, UInt8
-rgb: UInt8[np.ndarray, "H W 3"] = ...  # Height × Width × Channels
+from jaxtyping import Float, UInt8, Int
+rgb: UInt8[np.ndarray, "H W 3"] = ...
 intrinsics: Float[np.ndarray, "3 3"] = ...
+indices: Int[np.ndarray, "N"] = ...
 ```
+- Annotate variables using PEP 526-style assignments, even for intermediate values.
+- This verbosity keeps code self-documenting and enables static and runtime shape validation.
 
 ### Runtime Type Checking with Beartype
-**Critical**: Everything must be type annotated. The project uses `beartype_this_package()` for automatic runtime type validation:
-- All functions, classes, and variables are automatically type-checked at runtime
-- Use PEP 526-compliant annotated variable assignments whenever possible
-- JAXTyping is preferred for array types to enable shape validation
-- No need to manually add `@beartype` decorators - it's applied automatically
+The project uses `beartype_this_package()` for automatic runtime type validation:
+- All functions, classes, and variables are type-checked at runtime.
+- No need to manually add `@beartype` decorators.
 
 References: [beartype docs](https://beartype.readthedocs.io/en/latest/), [jaxtyping docs](https://docs.kidger.site/jaxtyping/)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,16 +41,21 @@ cam_points = cam_T_world @ world_points  # world → camera
 ```
 
 ### Type Safety
-All arrays use JAXTyping shape annotations:
+Runtime type checking via `beartype_this_package()` ensures all code is validated at runtime.
+
+- Every function and variable must include type annotations.
+- Use PEP 526–compliant annotated assignments wherever variables are defined.
+- No manual `@beartype` decorators are needed.
+
+### Array Type Annotations with JAXTyping
+Arrays must be annotated with both dtype and shape using jaxtyping:
 ```python
 from jaxtyping import Float, UInt8
 rgb: UInt8[np.ndarray, "H W 3"] = ...
+depth_map: Float[np.ndarray, "H W"] = ...
 ```
-
-**Critical**: Everything must be type annotated. Runtime type checking via `beartype_this_package()`:
-- All code is automatically validated at runtime - no manual `@beartype` decorators needed
-- Use PEP 526-compliant annotated variable assignments whenever possible  
-- Prefer JAXTyping for arrays to enable shape validation
+- Include dtype (`Float`, `UInt8`, etc.) and shape string in every array annotation.
+- Annotate array variables at assignment time, even for intermediates—the verbosity keeps code self-documenting.
 
 References: [beartype docs](https://beartype.readthedocs.io/en/latest/), [jaxtyping docs](https://docs.kidger.site/jaxtyping/)
 


### PR DESCRIPTION
## Summary
- clarify that all code must use annotated assignments
- document that arrays require jaxtyping with explicit shape and dtype

## Testing
- `pixi run ruff check .` *(fails: unused imports and type annotation issues in existing code)*
- `pixi run view-polycam-data --help` *(fails: ProxyError 403 when downloading example data)*

------
https://chatgpt.com/codex/tasks/task_e_688e1089800483289daf148e4cd5b84f