### PR TITLE
Ingest exoego script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ If you have a polycam zip file or extracted directory (from within the pixi shel
 python tools/view_polycam.py --polycam-zip-path $PATH-TO-POLYCAM-ZIP
 ```
 
+### Ingest Exo/Ego Recordings
+Ingest synchronized exo/ego captures into Rerun (spawns the viewer unless told otherwise).
+```bash
+simplecv-ingest-exoego --exoego-dir data/exoego-examples/adil-correct/adil3/
+```
+
+#### Handy flags
+- `--reencode-to-av1` ensures every clip is resized to ≤720p and re-encoded to AV1 MP4 before logging.
+- `--rr-config.headless` disables the Rerun UI (useful for automated runs).
+- `--rr-config.connect` or `--rr-config.serve` reuse an external/remote Rerun viewer.
+
+The CLI is Tyro-based, so tab completion and `--help` are available by default.
+
 
 ## T265 SLAM
 - **Env:** `t265` feature includes `librealsense==2.53.1` and `pyrealsense2==2.53.1.4623` (see `pyproject.toml`).

--- a/pixi.lock
+++ b/pixi.lock
@@ -12789,7 +12789,7 @@ packages:
 - pypi: ./
   name: simplecv
   version: 0.6.0
-  sha256: 216f07287cd31ecd071a9d8b9ad584aacc1bcb104e8a15f1a7b21675794d1d37
+  sha256: fe611f13df502b00f29d2a643f6a650585013e1f13caaf216af07831b5a0ac7d
   requires_dist:
   - jaxtyping<0.3.0
   - numpy>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "lovely-numpy>=0.2.13,<0.3",
 ]
 
+[project.scripts]
+simplecv-ingest-exoego = "simplecv.apis.ingest_exoego_recording:entrypoint"
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/simplecv/apis/ingest_exoego_recording.py
+++ b/simplecv/apis/ingest_exoego_recording.py
@@ -1,8 +1,10 @@
 import json
 import subprocess
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CompletedProcess
+from typing import cast
 
 import rerun as rr
 import rerun.blueprint as rrb
@@ -24,6 +26,8 @@ class IngestConfig:
     """Path to the directory containing 'exo' and/or 'ego' subdirectories with video files."""
     verbose: bool = False
     """Enable verbose console logging during ingestion."""
+    reencode_to_av1: bool = False
+    """Force AV1 MP4 re-encoding (with 720p ceiling) before logging videos."""
 
 
 def validate_exoego_dir(exoego_dir: Path) -> tuple[Path | None, Path | None]:
@@ -161,9 +165,10 @@ def prepare_video_for_logging(
     video_path: Path,
     *,
     verbose: bool = False,
+    reencode_to_av1: bool = False,
 ) -> PrepareVideoForLoggingResult:
     """
-    Ensure ``video_path`` is AV1 encoded, stored as MP4, and respects the 1280x720 ceiling.
+    Optionally ensure ``video_path`` is AV1 encoded, stored as MP4, and respects the 1280x720 ceiling.
 
     Returns:
         A ``PrepareVideoForLoggingResult`` capturing the prepared path, metadata, and
@@ -172,9 +177,17 @@ def prepare_video_for_logging(
     Args:
         video_path: Path to the source video on disk.
         verbose: Whether to emit detailed logging from the underlying encoding utilities.
+        reencode_to_av1: When true, convert non-AV1 content into AV1 MP4 constrained to 720p.
     """
 
     probe_result: VideoProbeResult = probe_video_stream(video_path)
+    if not reencode_to_av1:
+        return PrepareVideoForLoggingResult(
+            prepared_path=video_path,
+            metadata=probe_result,
+            should_cleanup=False,
+        )
+
     needs_reencode: bool = False
     resize_resolution: Resolution | None = None
 
@@ -249,6 +262,7 @@ def ingest_video_directory(
     timeline: str,
     verbose: bool,
     progress_label: str,
+    reencode_to_av1: bool,
 ) -> list[Path]:
     """Ingest the provided videos ensuring uniform encoding and resolution constraints.
 
@@ -260,25 +274,31 @@ def ingest_video_directory(
 
     expected_resolution: tuple[int, int] | None = None
     logged_video_entities: list[Path] = []
-    for entry in tqdm(video_entries, desc=progress_label, leave=False):
+    iterable_entries: Iterable[VideoIngestEntry] = cast(
+        Iterable[VideoIngestEntry],
+        tqdm(video_entries, desc=progress_label, leave=False),
+    )
+    for entry in iterable_entries:
         prepared_video_result: PrepareVideoForLoggingResult = prepare_video_for_logging(
             video_path=entry.source_path,
             verbose=verbose,
+            reencode_to_av1=reencode_to_av1,
         )
         prepared_path: Path = prepared_video_result.prepared_path
         metadata: VideoProbeResult = prepared_video_result.metadata
         should_cleanup: bool = prepared_video_result.should_cleanup
         actual_resolution: tuple[int, int] = (metadata.width, metadata.height)
 
-        if expected_resolution is None:
-            expected_resolution = actual_resolution
-        elif actual_resolution != expected_resolution:
-            if should_cleanup:
-                prepared_path.unlink(missing_ok=True)
-            raise ValueError(
-                f"Video {entry.source_path} has resolution {actual_resolution} which does not match "
-                f"the expected resolution {expected_resolution}."
-            )
+        if reencode_to_av1:
+            if expected_resolution is None:
+                expected_resolution = actual_resolution
+            elif actual_resolution != expected_resolution:
+                if should_cleanup:
+                    prepared_path.unlink(missing_ok=True)
+                raise ValueError(
+                    f"Video {entry.source_path} has resolution {actual_resolution} which does not match "
+                    f"the expected resolution {expected_resolution}."
+                )
 
         log_video(
             video_path=prepared_path,
@@ -377,6 +397,7 @@ def main(config: IngestConfig) -> None:
             timeline=timeline,
             verbose=config.verbose,
             progress_label="Ingesting exo videos",
+            reencode_to_av1=config.reencode_to_av1,
         )
 
     if ego_entries:
@@ -385,4 +406,5 @@ def main(config: IngestConfig) -> None:
             timeline=timeline,
             verbose=config.verbose,
             progress_label="Ingesting ego videos",
+            reencode_to_av1=config.reencode_to_av1,
         )

--- a/simplecv/apis/ingest_exoego_recording.py
+++ b/simplecv/apis/ingest_exoego_recording.py
@@ -8,11 +8,10 @@ from typing import cast
 
 import rerun as rr
 import rerun.blueprint as rrb
+import tyro
 from natsort import natsorted
 from rerun.blueprint import ContainerLike
 from tqdm.auto import tqdm
-
-import tyro
 
 from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from simplecv.video_utils import Resolution, reencode_video_optimal
@@ -71,12 +70,20 @@ class PrepareVideoForLoggingResult:
 
 @dataclass(frozen=True, slots=True)
 class VideoIngestEntry:
-    """Tuple-like container mapping a source video to its Rerun entity path."""
+    """Structured container coupling a source video with its camera/video entity paths."""
 
     source_path: Path
     """Filesystem path of the input video on disk."""
-    log_entity_path: Path
-    """Rerun entity path where the processed video will be logged."""
+    camera_log_path: Path
+    """Root Rerun entity path for this camera (e.g. '/world/exo/<camera_id>')."""
+    video_log_path: Path
+    """Rerun entity path for the video stream (e.g. '/world/exo/<camera_id>/pinhole/video')."""
+
+    @property
+    def pinhole_log_path(self) -> Path:
+        """Rerun entity path for the camera's pinhole node."""
+
+        return self.camera_log_path / "pinhole"
 
 
 def probe_video_stream(video_path: Path) -> VideoProbeResult:
@@ -251,7 +258,8 @@ def collect_video_entries(
     video_entries: list[VideoIngestEntry] = [
         VideoIngestEntry(
             source_path=video_path,
-            log_entity_path=log_root / video_path.stem,
+            camera_log_path=log_root / video_path.stem,
+            video_log_path=(log_root / video_path.stem / "pinhole" / "video"),
         )
         for video_path in all_video_paths
     ]
@@ -300,14 +308,14 @@ def ingest_video_directory(
                 raise ValueError(
                     f"Video {entry.source_path} has resolution {actual_resolution} which does not match "
                     f"the expected resolution {expected_resolution}."
-                )
+        )
 
         log_video(
             video_path=prepared_path,
-            video_log_path=entry.log_entity_path,
+            video_log_path=entry.video_log_path,
             timeline=timeline,
         )
-        logged_entity: Path = entry.log_entity_path
+        logged_entity: Path = entry.video_log_path
         logged_video_entities.append(logged_entity)
 
         if should_cleanup:
@@ -323,6 +331,8 @@ def create_ingest_view(
 ) -> ContainerLike:
     """
     Assemble a Rerun container/view showing exo videos along the bottom row and ego videos on the right column.
+
+    Paths should point to the `.../pinhole` entities that contain the actual video nodes.
     """
 
     main_view = rrb.Spatial3DView(origin="/")
@@ -330,9 +340,9 @@ def create_ingest_view(
     if ego_video_log_paths:
         ego_views = [
             rrb.Tabs(
-                rrb.Spatial2DView(origin=str(video_log_path)),
+                rrb.Spatial2DView(origin=str(pinhole_log_path)),
             )
-            for video_log_path in ego_video_log_paths
+            for pinhole_log_path in ego_video_log_paths
         ]
         main_view = rrb.Horizontal(
             contents=[
@@ -345,9 +355,9 @@ def create_ingest_view(
     if exo_video_log_paths:
         exo_views = [
             rrb.Tabs(
-                rrb.Spatial2DView(origin=str(video_log_path)),
+                rrb.Spatial2DView(origin=str(pinhole_log_path)),
             )
-            for video_log_path in exo_video_log_paths
+            for pinhole_log_path in exo_video_log_paths
         ]
         main_view = rrb.Vertical(
             contents=[
@@ -364,7 +374,7 @@ def main(config: IngestConfig) -> None:
     validate_exoego_dir(config.exoego_dir)
     print(f"Ingesting data from {config.exoego_dir} to RRD at {config.exoego_dir}")
 
-    parent_log_path: Path = Path("world")
+    parent_log_path: Path = Path("/world")
     timeline: str = "video_time"
     dir_tuple: tuple[Path | None, Path | None] = validate_exoego_dir(config.exoego_dir)
     exo_dir: Path | None = dir_tuple[0]
@@ -388,8 +398,8 @@ def main(config: IngestConfig) -> None:
     )
 
     ingest_view: ContainerLike = create_ingest_view(
-        exo_video_log_paths=[entry.log_entity_path for entry in exo_entries] or None,
-        ego_video_log_paths=[entry.log_entity_path for entry in ego_entries] or None,
+        exo_video_log_paths=[entry.pinhole_log_path for entry in exo_entries] or None,
+        ego_video_log_paths=[entry.pinhole_log_path for entry in ego_entries] or None,
     )
     rr.send_blueprint(rrb.Blueprint(ingest_view, collapse_panels=True))
 

--- a/simplecv/apis/ingest_exoego_recording.py
+++ b/simplecv/apis/ingest_exoego_recording.py
@@ -12,6 +12,8 @@ from natsort import natsorted
 from rerun.blueprint import ContainerLike
 from tqdm.auto import tqdm
 
+import tyro
+
 from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from simplecv.video_utils import Resolution, reencode_video_optimal
 
@@ -408,3 +410,18 @@ def main(config: IngestConfig) -> None:
             progress_label="Ingesting ego videos",
             reencode_to_av1=config.reencode_to_av1,
         )
+
+
+def entrypoint() -> None:
+    """Entrypoint leveraging Tyro to expose the ingest workflow via CLI."""
+
+    tyro.extras.set_accent_color("bright_cyan")
+    config: IngestConfig = tyro.cli(
+        IngestConfig,
+        description="Given a directory with ego/exo recordings, save them to RRD and visualize them with Rerun.",
+    )
+    main(config=config)
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/simplecv/apis/ingest_exoego_recording.py
+++ b/simplecv/apis/ingest_exoego_recording.py
@@ -1,10 +1,8 @@
 import json
 import subprocess
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CompletedProcess
-from typing import cast
 
 import rerun as rr
 import rerun.blueprint as rrb
@@ -25,7 +23,7 @@ class IngestConfig:
     exoego_dir: Path
     """Path to the directory containing 'exo' and/or 'ego' subdirectories with video files."""
     verbose: bool = False
-    """Enable verbose logging with progress bars during ingestion."""
+    """Enable verbose console logging during ingestion."""
 
 
 def validate_exoego_dir(exoego_dir: Path) -> tuple[Path | None, Path | None]:
@@ -159,41 +157,50 @@ def _coerce_int(value: object) -> int | None:
     return None
 
 
-def prepare_video_for_logging(video_path: Path) -> PrepareVideoForLoggingResult:
+def prepare_video_for_logging(
+    video_path: Path,
+    *,
+    verbose: bool = False,
+) -> PrepareVideoForLoggingResult:
     """
     Ensure ``video_path`` is AV1 encoded, stored as MP4, and respects the 1280x720 ceiling.
 
     Returns:
         A ``PrepareVideoForLoggingResult`` capturing the prepared path, metadata, and
         whether the prepared asset is temporary.
+
+    Args:
+        video_path: Path to the source video on disk.
+        verbose: Whether to emit detailed logging from the underlying encoding utilities.
     """
 
-    initial_probe: VideoProbeResult = probe_video_stream(video_path)
+    probe_result: VideoProbeResult = probe_video_stream(video_path)
     needs_reencode: bool = False
     resize_resolution: Resolution | None = None
 
-    if "mp4" not in _format_tokens(initial_probe.format_name):
+    if "mp4" not in _format_tokens(probe_result.format_name):
         needs_reencode = True
-    if initial_probe.codec_name != "av1":
+    if probe_result.codec_name != "av1":
         needs_reencode = True
-    if initial_probe.width > 1280 or initial_probe.height > 720:
+    if probe_result.width > 1280 or probe_result.height > 720:
         resize_resolution = "720p"
         needs_reencode = True
 
     if not needs_reencode:
-        if initial_probe.width > 1280 or initial_probe.height > 720:
+        if probe_result.width > 1280 or probe_result.height > 720:
             raise ValueError(
-                f"{video_path} exceeds the maximum resolution (found {initial_probe.width}x{initial_probe.height})."
+                f"{video_path} exceeds the maximum resolution (found {probe_result.width}x{probe_result.height})."
             )
         return PrepareVideoForLoggingResult(
             prepared_path=video_path,
-            metadata=initial_probe,
+            metadata=probe_result,
             should_cleanup=False,
         )
 
     prepared_video_path: Path = reencode_video_optimal(
         input_video_path=video_path,
         resize=resize_resolution,
+        verbose=verbose,
     )
     prepared_probe: VideoProbeResult = probe_video_stream(prepared_video_path)
 
@@ -253,21 +260,11 @@ def ingest_video_directory(
 
     expected_resolution: tuple[int, int] | None = None
     logged_video_entities: list[Path] = []
-    iterator: Iterable[VideoIngestEntry] = (
-        cast(
-            Iterable[VideoIngestEntry],
-            tqdm(
-                video_entries,
-                desc=progress_label,
-                leave=False,
-            ),
+    for entry in tqdm(video_entries, desc=progress_label, leave=False):
+        prepared_video_result: PrepareVideoForLoggingResult = prepare_video_for_logging(
+            video_path=entry.source_path,
+            verbose=verbose,
         )
-        if verbose
-        else cast(Iterable[VideoIngestEntry], video_entries)
-    )
-
-    for entry in iterator:
-        prepared_video_result: PrepareVideoForLoggingResult = prepare_video_for_logging(video_path=entry.source_path)
         prepared_path: Path = prepared_video_result.prepared_path
         metadata: VideoProbeResult = prepared_video_result.metadata
         should_cleanup: bool = prepared_video_result.should_cleanup

--- a/simplecv/video_utils.py
+++ b/simplecv/video_utils.py
@@ -383,17 +383,24 @@ def _select_optimal_video_encoder_args() -> tuple[str, list[str]]:
 def reencode_video_optimal(
     input_video_path: Path,
     *,
-    # NEW ------------------------------------------------------------
-    resize: Resolution | None = None,  # e.g. "720p" or None
-    # ----------------------------------------------------------------
+    resize: Resolution | None = None,
     delete_on_exit: bool = True,
     save_file: bool = False,
     output_directory: Path | None = None,
+    verbose: bool = False,
 ) -> Path:
     """
     Re-encode an existing video to AV1 (GPU when possible) and optionally
     downsample to 1080p / 720p / 360p, keeping everything else unchanged.
     Falls back to CPU encoders when NVIDIA NVENC is unavailable.
+
+    Args:
+        input_video_path: Path to the source video that should be re-encoded.
+        resize: Optional predefined resolution (e.g. ``"720p"``) used to downscale the video before logging.
+        delete_on_exit: Whether temporary files should be removed when the process exits.
+        save_file: If ``True``, write the re-encoded video next to the input file.
+        output_directory: Optional output directory when ``save_file`` is ``True``.
+        verbose: Emit FFmpeg timing information when ``True``.
     """
     if not input_video_path.is_file():
         raise FileNotFoundError(f"Input video file not found: {input_video_path}")
@@ -431,11 +438,12 @@ def reencode_video_optimal(
         str(output_path),
     ]
 
-    # ── run ffmpeg & handle errors (unchanged) ─────────────────────────────
+    # ── run ffmpeg & handle errors ─────────────────────────────────────────
     t0 = timer()
     proc = subprocess.run(cmd, capture_output=True)
     dt = timer() - t0
-    print(f"FFmpeg re-encoding using {encoder_name} completed in {dt:.2f} s")
+    if verbose:
+        print(f"FFmpeg re-encoding using {encoder_name} completed in {dt:.2f} s")
 
     if proc.returncode:
         if not save_file and output_path.exists():

--- a/simplecv/video_utils.py
+++ b/simplecv/video_utils.py
@@ -140,7 +140,6 @@ RESOLUTION_MAP: dict[Resolution, tuple[int, int]] = {
     "360p": (640, 360),
 }
 
-
 @lru_cache(maxsize=1)
 def _available_ffmpeg_video_encoders() -> set[str]:
     """
@@ -339,12 +338,13 @@ def _encoder_args_for(name: str, available: set[str]) -> list[str]:
 
 
 @lru_cache(maxsize=1)
-def _select_optimal_video_encoder_args() -> list[str]:
+def _select_optimal_video_encoder_args() -> tuple[str, list[str]]:
     """
     Choose ffmpeg video encoder arguments suited for the current platform.
 
     Returns:
-        List of ffmpeg CLI arguments (without output path or audio settings).
+        Tuple containing the encoder name and ffmpeg CLI arguments (without
+        output path or audio settings).
     """
     encoders = _available_ffmpeg_video_encoders()
 
@@ -356,7 +356,7 @@ def _select_optimal_video_encoder_args() -> list[str]:
                 f"Requested encoder '{env_encoder}' not available. "
                 f"Available encoders: {', '.join(sorted(encoders)) or 'none'}"
             )
-        return _encoder_args_for(env_encoder, encoders)
+        return env_encoder, _encoder_args_for(env_encoder, encoders)
 
     # Preferred order: NVIDIA NVENC → Intel QSV → VAAPI → libsvtav1 → libaom → Apple VT → x265 → x264
     priority = [
@@ -373,10 +373,11 @@ def _select_optimal_video_encoder_args() -> list[str]:
 
     for encoder in priority:
         if encoder in encoders:
-            return _encoder_args_for(encoder, encoders)
+            return encoder, _encoder_args_for(encoder, encoders)
 
     # No known encoder: return libx264 defaults to guarantee success.
-    return _encoder_args_for("libx264", encoders)
+    fallback = "libx264"
+    return fallback, _encoder_args_for(fallback, encoders)
 
 
 def reencode_video_optimal(
@@ -390,8 +391,9 @@ def reencode_video_optimal(
     output_directory: Path | None = None,
 ) -> Path:
     """
-    Re-encode an existing video to AV1 (NVENC) and-optionally-down-sample
-    to 1080p / 720p / 360p, keeping everything else unchanged.
+    Re-encode an existing video to AV1 (GPU when possible) and optionally
+    downsample to 1080p / 720p / 360p, keeping everything else unchanged.
+    Falls back to CPU encoders when NVIDIA NVENC is unavailable.
     """
     if not input_video_path.is_file():
         raise FileNotFoundError(f"Input video file not found: {input_video_path}")
@@ -421,7 +423,7 @@ def reencode_video_optimal(
         cmd += ["-vf", f"scale={w}:{h}"]
 
     # ── select encoder arguments based on platform capabilities ────────────
-    video_encoder_args = _select_optimal_video_encoder_args()
+    encoder_name, video_encoder_args = _select_optimal_video_encoder_args()
     cmd += video_encoder_args
     cmd += [
         "-c:a",
@@ -433,7 +435,7 @@ def reencode_video_optimal(
     t0 = timer()
     proc = subprocess.run(cmd, capture_output=True)
     dt = timer() - t0
-    print(f"FFmpeg re-encoding completed in {dt:.2f} s")
+    print(f"FFmpeg re-encoding using {encoder_name} completed in {dt:.2f} s")
 
     if proc.returncode:
         if not save_file and output_path.exists():

--- a/tools/ingest_exoego_recording.py
+++ b/tools/ingest_exoego_recording.py
@@ -1,12 +1,4 @@
-import tyro
+from simplecv.apis.ingest_exoego_recording import entrypoint
 
-from simplecv.apis.ingest_exoego_recording import IngestConfig, main
-
-# Example usage
 if __name__ == "__main__":
-    main(
-        tyro.cli(
-            IngestConfig,
-            description="Given a directory with ego/exo recordings, save them to RRD and visualize them with Rerun.",
-        )
-    )
+    entrypoint()


### PR DESCRIPTION
This pull request introduces a new CLI tool for ingesting synchronized exo/ego video recordings into Rerun, adds AV1 re-encoding capabilities, and refactors the ingestion workflow for greater clarity and flexibility. The main changes include the addition of the `simplecv-ingest-exoego` CLI, support for AV1 MP4 re-encoding with a 720p ceiling, improvements to entity path handling for Rerun logging and visualization, and enhanced verbose logging for video processing.

**New CLI tool and documentation:**
* Added `simplecv-ingest-exoego` CLI entrypoint for ingesting exo/ego recordings, with documentation and usage examples in `README.md`. The CLI supports tab completion and `--help` via Tyro. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R21-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R44) [[3]](diffhunk://#diff-802aa1165d2d1d45cfc41f7663ec44a254239eaefdb4b1846c024b2455c9bcf5L1-R4) [[4]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0R421-R437)

**Video ingest workflow improvements:**
* Refactored ingestion logic to use structured entity paths (`camera_log_path`, `video_log_path`, and `pinhole_log_path`) for proper Rerun visualization, and updated all relevant functions to use these paths. [[1]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L70-R86) [[2]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L232-R262) [[3]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0R334-R345) [[4]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L329-R360) [[5]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L372-R402)

**AV1 re-encoding and resolution enforcement:**
* Added `reencode_to_av1` flag to CLI and ingestion workflow to optionally force AV1 MP4 re-encoding and downscale videos to ≤720p before logging; updated `prepare_video_for_logging` and `reencode_video_optimal` to support this behavior and verbose logging. [[1]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L28-R31) [[2]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L162-R225) [[3]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0R275) [[4]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L256-R302) [[5]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L342-R347) [[6]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L376-R403) [[7]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L424-R446)

**Codebase and API improvements:**
* Improved function signatures, added docstrings, and clarified argument handling for video preparation and re-encoding utilities, including support for verbose FFmpeg output. [[1]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L143) [[2]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L359-R359) [[3]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L376-R403) [[4]](diffhunk://#diff-837589d570d2d486be4852d6221b8bb1e8112bbb46a48837e69dfbc50f6e1e52L424-R446)

**Miscellaneous fixes:**
* Standardized log path roots (e.g., `/world`), removed unused imports, and improved progress bar handling for verbose mode. [[1]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L348-R377) [[2]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0R11) [[3]](diffhunk://#diff-551538cfd67c3919dc3c64d8bd42eb58f558ba02ff1f8e7c8df335f834f0a0f0L256-R302)

Let me know if you want a walkthrough of how the new CLI works or details on the AV1 re-encoding logic!