### PR TITLE
Add Aria Gen2 Pilot dataset integration with H.265 VRS preprocessing and MPS hand tracking (Vibe Kanban)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -16281,7 +16281,7 @@ packages:
 - pypi: ./
   name: simplecv
   version: 0.7.2
-  sha256: b682964ab09a3e866a4dc1e594b954bdd3d5c530253caad9a7ef666deff622a7
+  sha256: cf73d24ad209ae657d702cc4522bf545f648463f38195782b27e9d07cc82f681
   requires_dist:
   - jaxtyping>=0.2.36,<0.3.0
   - numpy>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ description = "Download HOT3D Aria sequences from CDN URLs"
 cmd = "python tools/preprocess_hot3d.py"
 description = "Convert HOT3D VRS files to AV1 MP4 for simplecv"
 
+[tool.pixi.tasks.download-aria-gen2-pilot]
+cmd = "python tools/download_aria_gen2_pilot.py"
+description = "Download Aria Gen2 Pilot sequences from CDN URLs"
+
+[tool.pixi.tasks.preprocess-aria-gen2-pilot]
+cmd = "python tools/preprocess_aria_gen2_pilot.py"
+description = "Convert Aria Gen2 Pilot VRS files to AV1 MP4 for simplecv"
+
 [tool.pixi.tasks._download-example-polycam-data]
 cmd = """
     test -e data/example-room-scan-poly.zip

--- a/simplecv/apis/download_aria_gen2_pilot.py
+++ b/simplecv/apis/download_aria_gen2_pilot.py
@@ -146,6 +146,17 @@ def download_sequence(
         save_dir.mkdir(parents=True, exist_ok=True)
         dest_path: Path = save_dir / entry.filename
 
+        # Skip if the final output already exists (idempotent reruns).
+        # ZIPs are deleted after extraction, and main_vrs is renamed to
+        # video.vrs, so checking dest_path alone would re-download.
+        if dtype == "main_vrs" and (seq_dir / VRS_CANONICAL_NAME).exists():
+            continue
+        if entry.filename.endswith(".zip") and not dest_path.exists():
+            # ZIP was already extracted + deleted on a prior run — check if
+            # the extraction directory has content.
+            if any(save_dir.iterdir()):
+                continue
+
         # Download
         try:
             download_file(entry.download_url, dest_path, entry.file_size_bytes)
@@ -161,7 +172,7 @@ def download_sequence(
             success = False
             continue
 
-        # Extract ZIPs (may already be extracted + deleted from a prior run)
+        # Extract ZIPs
         if entry.filename.endswith(".zip") and dest_path.exists():
             extract_zip(dest_path, save_dir)
 

--- a/simplecv/apis/download_aria_gen2_pilot.py
+++ b/simplecv/apis/download_aria_gen2_pilot.py
@@ -27,7 +27,6 @@ DESIRED_DATA_TYPES: list[str] = [
     "mps_slam_trajectories",
     "mps_slam_calibration",
     "mps_hand_tracking",
-    "video_main_rgb",
 ]
 
 # Mapping from data type to subdirectory inside the sequence folder.

--- a/simplecv/apis/download_aria_gen2_pilot.py
+++ b/simplecv/apis/download_aria_gen2_pilot.py
@@ -12,12 +12,64 @@ Usage:
 
 from __future__ import annotations
 
-import json
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from serde import serde
+from serde.json import from_json
+
 from simplecv.apis.download_hot3d import download_file, extract_zip, verify_sha1
+
+# ── URL JSON schema (pyserde) ─────────────────────────────────────────── #
+
+
+@serde
+class DataTypeEntry:
+    """A single downloadable asset (VRS file, ZIP archive, etc.)."""
+
+    filename: str
+    """CDN filename, e.g. ``AriaGen2PilotDataset_v1.0_walk_1_main_recording.vrs``."""
+    sha1sum: str
+    """Expected SHA-1 hex digest for integrity verification."""
+    file_size_bytes: int
+    """Expected file size in bytes (used for skip-if-complete check)."""
+    download_url: str
+    """CDN download URL."""
+
+
+@serde
+class SequenceUrls:
+    """All downloadable assets for a single sequence."""
+
+    main_vrs: DataTypeEntry | None = None
+    video_main_rgb: DataTypeEntry | None = None
+    mps_slam_trajectories: DataTypeEntry | None = None
+    mps_slam_calibration: DataTypeEntry | None = None
+    mps_slam_points: DataTypeEntry | None = None
+    mps_slam_summary: DataTypeEntry | None = None
+    mps_hand_tracking: DataTypeEntry | None = None
+    mps_artifacts: DataTypeEntry | None = None
+    depth: DataTypeEntry | None = None
+    scene: DataTypeEntry | None = None
+    heart_rate: DataTypeEntry | None = None
+    diarization: DataTypeEntry | None = None
+    hand_object_interaction: DataTypeEntry | None = None
+
+    def get(self, data_type: str) -> DataTypeEntry | None:
+        """Look up a data type entry by name."""
+        return getattr(self, data_type, None)
+
+
+@serde
+class AriaGen2PilotUrlJson:
+    """Top-level schema for ``AriaGen2PilotDataset_download_urls.json``."""
+
+    sequences: dict[str, SequenceUrls]
+    """Mapping from sequence name (e.g. ``walk_1``) to its downloadable assets."""
+
+
+# ── Download configuration ────────────────────────────────────────────── #
 
 # Data types needed for simplecv integration (video + MPS trajectory/calibration + hand tracking).
 # Skip mps_artifacts (huge ~3.5GB), mps_slam_points (huge ~3.4GB), depth (large ~2GB),
@@ -67,9 +119,12 @@ class DownloadConfig:
     """Verify SHA1 checksums after download."""
 
 
+# ── Download logic ────────────────────────────────────────────────────── #
+
+
 def download_sequence(
     sequence_name: str,
-    sequence_data: dict[str, dict],
+    sequence_urls: SequenceUrls,
     output_dir: Path,
     data_types: list[str],
     verify: bool,
@@ -80,38 +135,33 @@ def download_sequence(
 
     success: bool = True
     for dtype in data_types:
-        if dtype not in sequence_data:
+        entry: DataTypeEntry | None = sequence_urls.get(dtype)
+        if entry is None:
             continue
-
-        info: dict = sequence_data[dtype]
-        filename: str = info["filename"]
-        url: str = info["download_url"]
-        expected_size: int = info["file_size_bytes"]
-        expected_sha1: str = info["sha1sum"]
 
         # Determine save location
         save_subdir: str = DATA_TYPE_SAVE_PATHS.get(dtype, ".")
         save_dir: Path = seq_dir / save_subdir
         save_dir.mkdir(parents=True, exist_ok=True)
-        dest_path: Path = save_dir / filename
+        dest_path: Path = save_dir / entry.filename
 
         # Download
         try:
-            download_file(url, dest_path, expected_size)
+            download_file(entry.download_url, dest_path, entry.file_size_bytes)
         except Exception as exc:
             print(f"  [FAIL] {dtype}: {exc}")
             success = False
             continue
 
         # Verify checksum
-        if verify and not verify_sha1(dest_path, expected_sha1):
-            print(f"  [FAIL] {dtype}: SHA1 mismatch for {filename}")
+        if verify and not verify_sha1(dest_path, entry.sha1sum):
+            print(f"  [FAIL] {dtype}: SHA1 mismatch for {entry.filename}")
             dest_path.unlink(missing_ok=True)
             success = False
             continue
 
         # Extract ZIPs
-        if filename.endswith(".zip"):
+        if entry.filename.endswith(".zip"):
             extract_zip(dest_path, save_dir)
 
         # Rename VRS to canonical name
@@ -127,12 +177,9 @@ def main(config: DownloadConfig) -> None:
     """Download Aria Gen2 Pilot sequences."""
     assert config.urls_json.exists(), f"URL JSON not found: {config.urls_json}"
 
-    with open(config.urls_json) as f:
-        data: dict = json.load(f)
+    url_json: AriaGen2PilotUrlJson = from_json(AriaGen2PilotUrlJson, config.urls_json.read_text())
 
-    sequences: dict[str, dict] = data["sequences"]
-    seq_names: list[str] = list(sequences.keys())
-
+    seq_names: list[str] = list(url_json.sequences.keys())
     if config.max_sequences is not None:
         seq_names = seq_names[: config.max_sequences]
 
@@ -145,7 +192,7 @@ def main(config: DownloadConfig) -> None:
         print(f"\n[{i + 1}/{len(seq_names)}] {seq_name}")
         ok: bool = download_sequence(
             sequence_name=seq_name,
-            sequence_data=sequences[seq_name],
+            sequence_urls=url_json.sequences[seq_name],
             output_dir=config.output_dir,
             data_types=config.data_types,
             verify=config.verify_sha1,

--- a/simplecv/apis/download_aria_gen2_pilot.py
+++ b/simplecv/apis/download_aria_gen2_pilot.py
@@ -1,0 +1,159 @@
+"""Download Aria Gen2 Pilot sequences from CDN URL JSON.
+
+Reads AriaGen2PilotDataset_download_urls.json and fetches selected data
+types for each sequence.
+
+Usage:
+    pixi run download-aria-gen2-pilot \
+        --urls-json /mnt/8tb/data/aria-gen2-pilot/AriaGen2PilotDataset_download_urls.json \
+        --output-dir /mnt/8tb/data/aria-gen2-pilot \
+        --max-sequences 2
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from simplecv.apis.download_hot3d import download_file, extract_zip, verify_sha1
+
+# Data types needed for simplecv integration (video + MPS trajectory/calibration + hand tracking).
+# Skip mps_artifacts (huge ~3.5GB), mps_slam_points (huge ~3.4GB), depth (large ~2GB),
+# scene, heart_rate, diarization, hand_object_interaction, and mps_slam_summary.
+DESIRED_DATA_TYPES: list[str] = [
+    "main_vrs",
+    "mps_slam_trajectories",
+    "mps_slam_calibration",
+    "mps_hand_tracking",
+    "video_main_rgb",
+]
+
+# Mapping from data type to subdirectory inside the sequence folder.
+# MPS data lives under mps/ following projectaria conventions.
+DATA_TYPE_SAVE_PATHS: dict[str, str] = {
+    "main_vrs": ".",
+    "video_main_rgb": ".",
+    "mps_slam_trajectories": "mps/slam",
+    "mps_slam_calibration": "mps/slam",
+    "mps_hand_tracking": "mps/hand_tracking",
+    "mps_slam_points": "mps/slam",
+    "mps_slam_summary": "mps/slam",
+    "mps_artifacts": "mps",
+    "depth": "depth",
+    "scene": "scene",
+    "heart_rate": "heart_rate",
+    "diarization": "diarization",
+    "hand_object_interaction": "hand_object_interaction",
+}
+
+# Aria Gen2 Pilot VRS canonical name (per sequence_config.main.recording).
+VRS_CANONICAL_NAME: str = "video.vrs"
+
+
+@dataclass
+class DownloadConfig:
+    """Configuration for Aria Gen2 Pilot download."""
+
+    urls_json: Path = Path("/mnt/8tb/data/aria-gen2-pilot/AriaGen2PilotDataset_download_urls.json")
+    """Path to the AriaGen2PilotDataset_download_urls.json file."""
+    output_dir: Path = Path("/mnt/8tb/data/aria-gen2-pilot")
+    """Output directory for downloaded sequences."""
+    max_sequences: int | None = None
+    """Maximum number of sequences to download (None = all)."""
+    data_types: list[str] = field(default_factory=lambda: DESIRED_DATA_TYPES)
+    """Data types to download per sequence."""
+    verify_sha1: bool = True
+    """Verify SHA1 checksums after download."""
+
+
+def download_sequence(
+    sequence_name: str,
+    sequence_data: dict[str, dict],
+    output_dir: Path,
+    data_types: list[str],
+    verify: bool,
+) -> bool:
+    """Download all requested data types for a single sequence."""
+    seq_dir: Path = output_dir / sequence_name
+    seq_dir.mkdir(parents=True, exist_ok=True)
+
+    success: bool = True
+    for dtype in data_types:
+        if dtype not in sequence_data:
+            continue
+
+        info: dict = sequence_data[dtype]
+        filename: str = info["filename"]
+        url: str = info["download_url"]
+        expected_size: int = info["file_size_bytes"]
+        expected_sha1: str = info["sha1sum"]
+
+        # Determine save location
+        save_subdir: str = DATA_TYPE_SAVE_PATHS.get(dtype, ".")
+        save_dir: Path = seq_dir / save_subdir
+        save_dir.mkdir(parents=True, exist_ok=True)
+        dest_path: Path = save_dir / filename
+
+        # Download
+        try:
+            download_file(url, dest_path, expected_size)
+        except Exception as exc:
+            print(f"  [FAIL] {dtype}: {exc}")
+            success = False
+            continue
+
+        # Verify checksum
+        if verify and not verify_sha1(dest_path, expected_sha1):
+            print(f"  [FAIL] {dtype}: SHA1 mismatch for {filename}")
+            dest_path.unlink(missing_ok=True)
+            success = False
+            continue
+
+        # Extract ZIPs
+        if filename.endswith(".zip"):
+            extract_zip(dest_path, save_dir)
+
+        # Rename VRS to canonical name
+        if dtype == "main_vrs" and dest_path.exists():
+            canonical: Path = seq_dir / VRS_CANONICAL_NAME
+            if not canonical.exists():
+                shutil.move(str(dest_path), str(canonical))
+
+    return success
+
+
+def main(config: DownloadConfig) -> None:
+    """Download Aria Gen2 Pilot sequences."""
+    assert config.urls_json.exists(), f"URL JSON not found: {config.urls_json}"
+
+    with open(config.urls_json) as f:
+        data: dict = json.load(f)
+
+    sequences: dict[str, dict] = data["sequences"]
+    seq_names: list[str] = list(sequences.keys())
+
+    if config.max_sequences is not None:
+        seq_names = seq_names[: config.max_sequences]
+
+    print(f"Downloading {len(seq_names)} sequences to {config.output_dir}")
+    print(f"Data types: {config.data_types}")
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    for i, seq_name in enumerate(seq_names):
+        print(f"\n[{i + 1}/{len(seq_names)}] {seq_name}")
+        ok: bool = download_sequence(
+            sequence_name=seq_name,
+            sequence_data=sequences[seq_name],
+            output_dir=config.output_dir,
+            data_types=config.data_types,
+            verify=config.verify_sha1,
+        )
+        if ok:
+            print(f"  [OK] {seq_name}")
+        else:
+            print(f"  [PARTIAL] {seq_name}")
+
+    print(f"\nDone. Downloaded {len(seq_names)} sequences to {config.output_dir}")

--- a/simplecv/apis/download_aria_gen2_pilot.py
+++ b/simplecv/apis/download_aria_gen2_pilot.py
@@ -18,8 +18,9 @@ from pathlib import Path
 
 from serde import serde
 from serde.json import from_json
+from tqdm import tqdm
 
-from simplecv.apis.download_hot3d import download_file, extract_zip, verify_sha1
+from simplecv.apis.download_utils import download_file, extract_zip, verify_sha1
 
 # ── URL JSON schema (pyserde) ─────────────────────────────────────────── #
 
@@ -183,13 +184,10 @@ def main(config: DownloadConfig) -> None:
     if config.max_sequences is not None:
         seq_names = seq_names[: config.max_sequences]
 
-    print(f"Downloading {len(seq_names)} sequences to {config.output_dir}")
     print(f"Data types: {config.data_types}")
-
     config.output_dir.mkdir(parents=True, exist_ok=True)
 
-    for i, seq_name in enumerate(seq_names):
-        print(f"\n[{i + 1}/{len(seq_names)}] {seq_name}")
+    for seq_name in tqdm(seq_names, desc="Downloading sequences"):
         ok: bool = download_sequence(
             sequence_name=seq_name,
             sequence_urls=url_json.sequences[seq_name],
@@ -197,9 +195,5 @@ def main(config: DownloadConfig) -> None:
             data_types=config.data_types,
             verify=config.verify_sha1,
         )
-        if ok:
-            print(f"  [OK] {seq_name}")
-        else:
-            print(f"  [PARTIAL] {seq_name}")
-
-    print(f"\nDone. Downloaded {len(seq_names)} sequences to {config.output_dir}")
+        status: str = "OK" if ok else "PARTIAL"
+        tqdm.write(f"  [{status}] {seq_name}")

--- a/simplecv/apis/download_aria_gen2_pilot.py
+++ b/simplecv/apis/download_aria_gen2_pilot.py
@@ -160,8 +160,8 @@ def download_sequence(
             success = False
             continue
 
-        # Extract ZIPs
-        if entry.filename.endswith(".zip"):
+        # Extract ZIPs (may already be extracted + deleted from a prior run)
+        if entry.filename.endswith(".zip") and dest_path.exists():
             extract_zip(dest_path, save_dir)
 
         # Rename VRS to canonical name

--- a/simplecv/apis/download_hot3d.py
+++ b/simplecv/apis/download_hot3d.py
@@ -12,15 +12,15 @@ Usage:
 
 from __future__ import annotations
 
-import hashlib
 import json
 import shutil
-import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import requests
-from tqdm import tqdm
+from simplecv.apis.download_utils import download_file, extract_zip, verify_sha1
+
+# Re-export for backwards compatibility
+__all__ = ["download_file", "extract_zip", "verify_sha1"]
 
 # Data types we want for simplecv integration. Skip mps_slam_points (huge, 400MB+)
 # and mps_artifacts (huge, 460MB+) and mps_slam_summary (trivial).
@@ -67,44 +67,6 @@ class DownloadConfig:
     """Data types to download per sequence."""
     verify_sha1: bool = True
     """Verify SHA1 checksums after download."""
-
-
-def download_file(url: str, dest_path: Path, expected_size: int | None = None) -> None:
-    """Download a file with progress bar, skipping if already complete."""
-    if dest_path.exists() and expected_size is not None and dest_path.stat().st_size == expected_size:
-        return  # Already downloaded
-    dest_path.parent.mkdir(parents=True, exist_ok=True)
-
-    response: requests.Response = requests.get(url, stream=True, timeout=120)
-    response.raise_for_status()
-    total_size: int = int(response.headers.get("content-length", 0))
-
-    with open(dest_path, "wb") as f, tqdm(
-        total=total_size,
-        unit="B",
-        unit_scale=True,
-        desc=dest_path.name,
-        leave=False,
-    ) as pbar:
-        for chunk in response.iter_content(chunk_size=8192):
-            f.write(chunk)
-            pbar.update(len(chunk))
-
-
-def verify_sha1(file_path: Path, expected_sha1: str) -> bool:
-    """Verify SHA1 checksum of a downloaded file."""
-    sha1 = hashlib.sha1()
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):
-            sha1.update(chunk)
-    return sha1.hexdigest() == expected_sha1
-
-
-def extract_zip(zip_path: Path, extract_dir: Path) -> None:
-    """Extract a ZIP file and remove the archive."""
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        zf.extractall(extract_dir)
-    zip_path.unlink()
 
 
 def download_sequence(

--- a/simplecv/apis/download_utils.py
+++ b/simplecv/apis/download_utils.py
@@ -1,0 +1,48 @@
+"""Shared download utilities for CDN-hosted datasets."""
+
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from pathlib import Path
+
+import requests
+from tqdm import tqdm
+
+
+def download_file(url: str, dest_path: Path, expected_size: int | None = None) -> None:
+    """Download a file with progress bar, skipping if already complete."""
+    if dest_path.exists() and expected_size is not None and dest_path.stat().st_size == expected_size:
+        return  # Already downloaded
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    response: requests.Response = requests.get(url, stream=True, timeout=120)
+    response.raise_for_status()
+    total_size: int = int(response.headers.get("content-length", 0))
+
+    with open(dest_path, "wb") as f, tqdm(
+        total=total_size,
+        unit="B",
+        unit_scale=True,
+        desc=dest_path.name,
+        leave=False,
+    ) as pbar:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+            pbar.update(len(chunk))
+
+
+def verify_sha1(file_path: Path, expected_sha1: str) -> bool:
+    """Verify SHA1 checksum of a downloaded file."""
+    sha1 = hashlib.sha1()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            sha1.update(chunk)
+    return sha1.hexdigest() == expected_sha1
+
+
+def extract_zip(zip_path: Path, extract_dir: Path) -> None:
+    """Extract a ZIP file and remove the archive."""
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(extract_dir)
+    zip_path.unlink()

--- a/simplecv/apis/download_utils.py
+++ b/simplecv/apis/download_utils.py
@@ -42,7 +42,15 @@ def verify_sha1(file_path: Path, expected_sha1: str) -> bool:
 
 
 def extract_zip(zip_path: Path, extract_dir: Path) -> None:
-    """Extract a ZIP file and remove the archive."""
+    """Extract a ZIP file and remove the archive.
+
+    Validates member paths to prevent Zip Slip (path traversal).
+    """
+    extract_root: Path = extract_dir.resolve()
     with zipfile.ZipFile(zip_path, "r") as zf:
+        for member in zf.infolist():
+            member_path: Path = (extract_root / member.filename).resolve()
+            if extract_root not in member_path.parents and member_path != extract_root:
+                raise ValueError(f"Unsafe ZIP member path {member.filename!r} in {zip_path}")
         zf.extractall(extract_dir)
     zip_path.unlink()

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -1,0 +1,294 @@
+"""One-time VRS → MP4 conversion for Aria Gen2 Pilot sequences.
+
+Aria Gen2 encodes video streams as H.265 inside VRS (unlike Gen1 which uses
+JPEG). This script extracts H.265 NAL units from VRS, writes them to a temp
+Annex-B file, then transcodes to H.265 MP4 via PyAV.
+
+For the RGB stream, the download provides a preview MP4 which is used directly
+(just copied + timestamps extracted from VRS).
+
+Usage:
+    pixi run preprocess-aria-gen2-pilot --root /mnt/8tb/data/aria-gen2-pilot
+    pixi run preprocess-aria-gen2-pilot --root /mnt/8tb/data/aria-gen2-pilot --sequence walk_1
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import time
+from dataclasses import dataclass, field
+from fractions import Fraction
+from pathlib import Path
+
+import av
+import pyvrs
+from tqdm import tqdm
+
+from simplecv.data.hot3d_utils import (
+    Hot3dSequenceCalibration,
+    Hot3dStreamCalibration,
+    parse_online_calibration_first,
+    save_calibration,
+)
+
+# ── Aria Gen2 stream mapping ──────────────────────────────────────────── #
+# Gen2 has 5 cameras vs Gen1's 3, with different SLAM camera labels.
+
+ARIA_GEN2_STREAM_ID_TO_LABEL: dict[str, str] = {
+    "214-1": "camera-rgb",
+    "1201-1": "slam-front-left",
+    "1201-2": "slam-front-right",
+    "1201-3": "slam-side-left",
+    "1201-4": "slam-side-right",
+}
+
+ARIA_GEN2_STREAM_LABEL_TO_FILENAME: dict[str, str] = {
+    "camera-rgb": "rgb.mp4",
+    "slam-front-left": "slam_front_left.mp4",
+    "slam-front-right": "slam_front_right.mp4",
+    "slam-side-left": "slam_side_left.mp4",
+    "slam-side-right": "slam_side_right.mp4",
+}
+
+# Default streams to extract
+ARIA_GEN2_STREAM_IDS: list[str] = ["214-1", "1201-1", "1201-2", "1201-3", "1201-4"]
+
+OUTPUT_DIR_NAME: str = "_simplecv"
+VRS_FILENAME: str = "video.vrs"
+
+
+@dataclass
+class PreprocessConfig:
+    """Configuration for Aria Gen2 Pilot VRS preprocessing."""
+
+    root: Path = Path("/mnt/8tb/data/aria-gen2-pilot")
+    """Root directory containing sequence folders."""
+    sequence: str = ""
+    """Process a single sequence (empty = all sequences with video.vrs)."""
+    skip_existing: bool = True
+    """Skip sequences that already have _simplecv/ output."""
+    streams: list[str] = field(default_factory=list)
+    """VRS stream IDs to extract. Empty = default Aria Gen2 streams."""
+
+
+def _extract_vrs_timestamps(vrs_path: Path, stream_id: str) -> list[int]:
+    """Read VRS timestamps for a stream without decoding images.
+
+    Returns list of nanosecond timestamps in device-time domain.
+    """
+    reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
+    filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
+    timestamps_ns: list[int] = []
+    for rec in filtered:
+        timestamps_ns.append(int(rec.timestamp * 1e9))
+    return timestamps_ns
+
+
+def _get_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
+    """Read image dimensions from VRS stream image_spec.
+
+    Returns (width, height).
+    """
+    reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
+    filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
+    for rec in filtered:
+        if rec.image_specs:
+            spec = rec.image_specs[0]
+            return spec.width, spec.height
+        break
+    raise ValueError(f"Could not determine dimensions for stream {stream_id}")
+
+
+def transcode_h265_stream_to_mp4(
+    vrs_path: Path,
+    stream_id: str,
+    output_path: Path,
+) -> list[int]:
+    """Extract H.265 NAL units from VRS, transcode to H.265 MP4.
+
+    Approach:
+    1. Read raw H.265 NAL units from VRS (Annex-B format, fast)
+    2. Write to temp .h265 file
+    3. Decode with PyAV → re-encode to H.265 MP4
+
+    Returns list of VRS timestamps in nanoseconds.
+    """
+    reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
+    label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
+    info: dict = reader.get_stream_info(stream_id)
+    n_frames: int = info["data_records_count"]
+
+    # Phase 1: Read raw H.265 NAL units from VRS
+    t0: float = time.perf_counter()
+    filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
+    nal_units: list[bytes] = []
+    timestamps_ns: list[int] = []
+    for rec in tqdm(filtered, total=n_frames, desc=f"Reading {label}", leave=False):
+        if rec.n_image_blocks > 0:
+            nal_units.append(rec.image_blocks[0].tobytes())
+            timestamps_ns.append(int(rec.timestamp * 1e9))
+    t_read: float = time.perf_counter() - t0
+
+    if not nal_units:
+        print(f"  [WARN] No frames in stream {stream_id}")
+        return []
+
+    # Phase 2: Write Annex-B bitstream to temp file
+    tmp_h265 = tempfile.NamedTemporaryFile(suffix=".h265", delete=False)
+    for nal in nal_units:
+        tmp_h265.write(nal)
+    tmp_h265.close()
+    tmp_path: Path = Path(tmp_h265.name)
+
+    # Phase 3: Decode → re-encode to H.265 MP4
+    t1: float = time.perf_counter()
+
+    if len(timestamps_ns) > 1:
+        dt_ns: float = float(timestamps_ns[-1] - timestamps_ns[0]) / (len(timestamps_ns) - 1)
+        fps: int = max(1, round(1e9 / dt_ns))
+    else:
+        fps = 30
+
+    inp = av.open(str(tmp_path))
+    in_stream = inp.streams.video[0]
+
+    out = av.open(str(output_path), "w")
+    out_stream = out.add_stream("hevc", rate=Fraction(fps, 1))
+    out_stream.width = in_stream.codec_context.width
+    out_stream.height = in_stream.codec_context.height
+    out_stream.pix_fmt = in_stream.codec_context.pix_fmt or "gray"
+
+    frame_count: int = 0
+    for frame in tqdm(inp.decode(in_stream), total=len(nal_units), desc=f"Transcode {label}", leave=False):
+        frame.pts = frame_count
+        for packet in out_stream.encode(frame):
+            out.mux(packet)
+        frame_count += 1
+
+    # Flush encoder
+    for packet in out_stream.encode():
+        out.mux(packet)
+
+    out.close()
+    inp.close()
+    tmp_path.unlink()
+
+    t_transcode: float = time.perf_counter() - t1
+    t_total: float = t_read + t_transcode
+    print(
+        f"  {label}: {frame_count} frames, {fps}fps → {output_path.name} "
+        f"({t_total:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
+    )
+    return timestamps_ns
+
+
+def _find_preview_mp4(seq_dir: Path) -> Path | None:
+    """Find the preview RGB MP4 downloaded alongside the VRS."""
+    candidates: list[Path] = list(seq_dir.glob("*_preview_rgb.mp4"))
+    if candidates:
+        return candidates[0]
+    return None
+
+
+def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
+    """Preprocess a single Aria Gen2 Pilot sequence."""
+    vrs_path: Path = seq_dir / VRS_FILENAME
+    if not vrs_path.exists():
+        print(f"  [SKIP] No {VRS_FILENAME} in {seq_dir}")
+        return
+
+    streams: list[str] = config.streams if config.streams else ARIA_GEN2_STREAM_IDS
+
+    output_dir: Path = seq_dir / OUTPUT_DIR_NAME
+    if config.skip_existing and output_dir.exists():
+        expected_files: list[str] = ["calibration.json", "timestamps_ns.json"]
+        for sid in streams:
+            label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(sid, sid)
+            expected_files.append(ARIA_GEN2_STREAM_LABEL_TO_FILENAME.get(label, f"{label}.mp4"))
+        if all((output_dir / f).exists() for f in expected_files):
+            print(f"  [SKIP] Already preprocessed: {seq_dir.name}")
+            return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    t_seq_start: float = time.perf_counter()
+    print(f"  Streams: {streams}")
+
+    # ── Extract calibration with correct dimensions ──────────────────────
+    cal_jsonl: Path = seq_dir / "mps" / "slam" / "online_calibration.jsonl"
+    if not cal_jsonl.exists():
+        print("  [WARN] No online_calibration.jsonl found, skipping")
+        return
+
+    cal: Hot3dSequenceCalibration = parse_online_calibration_first(cal_jsonl)
+
+    # Fix image dimensions from VRS (online_calibration uses approximate cx*2/cy*2)
+    vrs_dims: dict[str, tuple[int, int]] = {}
+    for sid in streams:
+        label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(sid, sid)
+        try:
+            w, h = _get_stream_dimensions(vrs_path, sid)
+            vrs_dims[label] = (w, h)
+        except ValueError:
+            pass
+
+    for stream_cal in cal.streams:
+        if stream_cal.stream_label in vrs_dims:
+            stream_cal.width, stream_cal.height = vrs_dims[stream_cal.stream_label]
+
+    save_calibration(cal, output_dir / "calibration.json")
+    print(f"  Calibration: {len(cal.streams)} streams, dims patched from VRS")
+
+    # ── Extract video streams ─────────────────────────────────────────────
+    all_timestamps: dict[str, list[int]] = {}
+
+    for stream_id in streams:
+        label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
+        filename: str = ARIA_GEN2_STREAM_LABEL_TO_FILENAME.get(label, f"{label}.mp4")
+        output_path: Path = output_dir / filename
+
+        if label == "camera-rgb":
+            # RGB: use preview MP4 if available (much faster than VRS transcode)
+            preview: Path | None = _find_preview_mp4(seq_dir)
+            if preview is not None:
+                shutil.copy2(str(preview), str(output_path))
+                timestamps: list[int] = _extract_vrs_timestamps(vrs_path, stream_id)
+                all_timestamps[label] = timestamps
+                print(f"  {label}: copied preview MP4 ({preview.name}), {len(timestamps)} VRS timestamps")
+                continue
+
+        # SLAM cameras (or RGB fallback): H.265 transcode from VRS
+        timestamps = transcode_h265_stream_to_mp4(
+            vrs_path=vrs_path,
+            stream_id=stream_id,
+            output_path=output_path,
+        )
+        all_timestamps[label] = timestamps
+
+    # Save timestamps
+    ts_path: Path = output_dir / "timestamps_ns.json"
+    ts_path.write_text(json.dumps(all_timestamps))
+
+    t_seq_elapsed: float = time.perf_counter() - t_seq_start
+    print(f"  Done in {t_seq_elapsed:.1f}s ({len(streams)} streams)")
+
+
+def main(config: PreprocessConfig) -> None:
+    """Preprocess Aria Gen2 Pilot VRS files."""
+    root: Path = config.root
+    assert root.exists(), f"Root directory not found: {root}"
+
+    if config.sequence:
+        seq_dir: Path = root / config.sequence
+        assert seq_dir.exists(), f"Sequence not found: {seq_dir}"
+        print(f"Processing: {config.sequence}")
+        preprocess_sequence(seq_dir, config)
+    else:
+        seq_dirs: list[Path] = sorted([d for d in root.iterdir() if d.is_dir() and (d / VRS_FILENAME).exists()])
+        print(f"Found {len(seq_dirs)} sequences with {VRS_FILENAME}")
+        for i, seq_dir in enumerate(seq_dirs):
+            print(f"\n[{i + 1}/{len(seq_dirs)}] {seq_dir.name}")
+            preprocess_sequence(seq_dir, config)
+
+    print("\nPreprocessing complete.")

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -1,8 +1,8 @@
 """One-time VRS → MP4 conversion for Aria Gen2 Pilot sequences.
 
 Aria Gen2 encodes video streams as H.265 inside VRS (unlike Gen1 which uses
-JPEG). This script extracts H.265 NAL units from VRS, writes them to a temp
-Annex-B file, then transcodes to H.265 MP4 via PyAV.
+JPEG). This script extracts H.265 NAL units from VRS and **remuxes** them
+into MP4 containers without decode/encode — ~130x faster than transcoding.
 
 For the RGB stream, the download provides a preview MP4 which is used directly
 (just copied + timestamps extracted from VRS).
@@ -14,9 +14,9 @@ Usage:
 
 from __future__ import annotations
 
+import io
 import json
 import shutil
-import tempfile
 import time
 from dataclasses import dataclass, field
 from fractions import Fraction
@@ -101,17 +101,20 @@ def _get_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
     raise ValueError(f"Could not determine dimensions for stream {stream_id}")
 
 
-def transcode_h265_stream_to_mp4(
+def remux_h265_stream_to_mp4(
     vrs_path: Path,
     stream_id: str,
     output_path: Path,
 ) -> list[int]:
-    """Extract H.265 NAL units from VRS, transcode to H.265 MP4.
+    """Extract H.265 NAL units from VRS and remux to MP4 (no decode/encode).
 
-    Approach:
-    1. Read raw H.265 NAL units from VRS (Annex-B format, fast)
-    2. Write to temp .h265 file
-    3. Decode with PyAV → re-encode to H.265 MP4
+    Approach (following the ``mux_h264_to_mp4`` pattern in rerun_log_utils):
+    1. Read raw H.265 Annex-B NAL units from VRS image blocks
+    2. Concatenate into a single bytestream, open as raw HEVC input
+    3. Demux packets and remux into MP4 with VRS device-time timestamps
+
+    This is ~130x faster than a full transcode since no decode or encode
+    occurs — packets are copied directly from VRS to MP4.
 
     Returns list of VRS timestamps in nanoseconds.
     """
@@ -120,7 +123,7 @@ def transcode_h265_stream_to_mp4(
     info: dict = reader.get_stream_info(stream_id)
     n_frames: int = info["data_records_count"]
 
-    # Phase 1: Read raw H.265 NAL units from VRS
+    # Phase 1: Read raw H.265 NAL units + timestamps from VRS
     t0: float = time.perf_counter()
     filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
     nal_units: list[bytes] = []
@@ -135,57 +138,39 @@ def transcode_h265_stream_to_mp4(
         print(f"  [WARN] No frames in stream {stream_id}")
         return []
 
-    # Phase 2: Write Annex-B bitstream to temp file
-    tmp_h265 = tempfile.NamedTemporaryFile(suffix=".h265", delete=False)
-    for nal in nal_units:
-        tmp_h265.write(nal)
-    tmp_h265.close()
-    tmp_path: Path = Path(tmp_h265.name)
-
-    # Phase 3: Decode → re-encode to H.265 MP4
+    # Phase 2: Remux — concatenate NAL units, open as raw HEVC, copy packets
     t1: float = time.perf_counter()
+    sample_bytes: io.BytesIO = io.BytesIO(b"".join(nal_units))
 
-    if len(timestamps_ns) > 1:
-        dt_ns: float = float(timestamps_ns[-1] - timestamps_ns[0]) / (len(timestamps_ns) - 1)
-        fps: int = max(1, round(1e9 / dt_ns))
-    else:
-        fps = 30
+    input_container = av.open(sample_bytes, mode="r", format="hevc")
+    input_stream = input_container.streams.video[0]
 
-    inp = av.open(str(tmp_path))
-    in_stream = inp.streams.video[0]
+    output_container = av.open(str(output_path), mode="w")
+    output_stream = output_container.add_stream_from_template(input_stream)
+    # Nanosecond time_base preserves exact VRS timestamps without fps rounding.
+    ns_time_base: Fraction = Fraction(1, 1_000_000_000)
+    output_stream.time_base = ns_time_base
+    if output_stream.codec_context is not None:
+        output_stream.codec_context.time_base = ns_time_base
 
-    out = av.open(str(output_path), "w")
-    out_stream = out.add_stream("hevc", rate=Fraction(fps, 1))
-    out_stream.width = in_stream.codec_context.width
-    out_stream.height = in_stream.codec_context.height
-    out_stream.pix_fmt = in_stream.codec_context.pix_fmt or "gray"
-    # Force a fixed time_base so PTS increments are meaningful.
-    out_stream.time_base = Fraction(1, fps)
-
+    start_ns: int = timestamps_ns[0]
     frame_count: int = 0
-    for frame in tqdm(inp.decode(in_stream), total=len(nal_units), desc=f"Transcode {label}", leave=False):
-        # Decoded frames from raw Annex-B have pts=None.  Assign monotonic
-        # PTS in units of (1/fps) so each frame advances by exactly 1 tick.
-        frame.pts = frame_count
-        frame.dts = frame_count
-        frame.time_base = Fraction(1, fps)
-        for packet in out_stream.encode(frame):
-            out.mux(packet)
+    for packet, ts_ns in zip(input_container.demux(input_stream), timestamps_ns, strict=False):
+        packet.time_base = ns_time_base
+        packet.pts = ts_ns - start_ns
+        packet.dts = packet.pts  # No B-frames in VRS H.265 (all I-frames)
+        packet.stream = output_stream
+        output_container.mux(packet)
         frame_count += 1
 
-    # Flush encoder
-    for packet in out_stream.encode():
-        out.mux(packet)
+    input_container.close()
+    output_container.close()
 
-    out.close()
-    inp.close()
-    tmp_path.unlink()
-
-    t_transcode: float = time.perf_counter() - t1
-    t_total: float = t_read + t_transcode
+    t_remux: float = time.perf_counter() - t1
+    t_total: float = t_read + t_remux
     print(
-        f"  {label}: {frame_count} frames, {fps}fps → {output_path.name} "
-        f"({t_total:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
+        f"  {label}: {frame_count} frames → {output_path.name} "
+        f"({t_total:.1f}s: read {t_read:.1f}s, remux {t_remux:.1f}s)"
     )
     return timestamps_ns
 
@@ -264,8 +249,8 @@ def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
                 print(f"  {label}: copied preview MP4 ({preview.name}), {len(timestamps)} VRS timestamps")
                 continue
 
-        # SLAM cameras (or RGB fallback): H.265 transcode from VRS
-        timestamps = transcode_h265_stream_to_mp4(
+        # SLAM cameras (or RGB fallback): H.265 remux from VRS (no decode/encode)
+        timestamps = remux_h265_stream_to_mp4(
             vrs_path=vrs_path,
             stream_id=stream_id,
             output_path=output_path,

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -1,12 +1,9 @@
 """One-time VRS → AV1 MP4 conversion for Aria Gen2 Pilot sequences.
 
 Aria Gen2 encodes video streams as H.265 inside VRS (unlike Gen1 which uses
-JPEG). The SLAM cameras use monochrome (gray8) H.265 Rext profile which
-neither Rerun nor NVDEC can decode, so we transcode to yuv420p AV1 via
-ffmpeg + NVENC (~4s per 10k-frame stream).
-
-For the RGB stream, the download provides a preview MP4 which is copied
-directly (timestamps still extracted from VRS for pose alignment).
+JPEG). All streams (RGB + SLAM) use monochrome (gray8) H.265 Rext profile
+which neither Rerun nor NVDEC can decode, so we transcode to yuv420p AV1
+via ffmpeg + NVENC (~4s per 10k-frame SLAM stream, ~8s for RGB).
 
 Usage:
     pixi run preprocess-aria-gen2-pilot --root /mnt/8tb/data/aria-gen2-pilot
@@ -73,22 +70,26 @@ class PreprocessConfig:
 # ── VRS helpers ───────────────────────────────────────────────────────── #
 
 
-def _read_vrs_stream(
-    vrs_path: Path, stream_id: str, label: str,
-) -> tuple[list[bytes], list[int]]:
-    """Read raw image blocks + nanosecond timestamps from a VRS stream."""
+def _stream_vrs_to_file(
+    vrs_path: Path, stream_id: str, label: str, dest: Path,
+) -> list[int]:
+    """Stream raw image blocks from VRS directly to a file, collecting timestamps.
+
+    Writes encoded blocks as they're read instead of buffering in memory,
+    keeping peak RAM bounded regardless of stream size.
+    """
     reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
     info: dict = reader.get_stream_info(stream_id)
     n_frames: int = info["data_records_count"]
     filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
 
-    image_blocks: list[bytes] = []
     timestamps_ns: list[int] = []
-    for rec in tqdm(filtered, total=n_frames, desc=f"Reading {label}", leave=False):
-        if rec.n_image_blocks > 0:
-            image_blocks.append(rec.image_blocks[0].tobytes())
-            timestamps_ns.append(int(rec.timestamp * 1e9))
-    return image_blocks, timestamps_ns
+    with open(dest, "wb") as f:
+        for rec in tqdm(filtered, total=n_frames, desc=f"Reading {label}", leave=False):
+            if rec.n_image_blocks > 0:
+                f.write(rec.image_blocks[0].tobytes())
+                timestamps_ns.append(int(rec.timestamp * 1e9))
+    return timestamps_ns
 
 
 def _get_vrs_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
@@ -99,7 +100,6 @@ def _get_vrs_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int
         if rec.image_specs:
             spec = rec.image_specs[0]
             return spec.width, spec.height
-        break
     raise ValueError(f"Could not determine dimensions for stream {stream_id}")
 
 
@@ -137,33 +137,32 @@ def transcode_h265_stream_to_mp4(
     label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
     cq: int | None = None if label == "camera-rgb" else _CQ_SLAM
 
+    # Stream VRS directly to temp file (no in-memory buffering)
     t0: float = time.perf_counter()
-    nal_units, timestamps_ns = _read_vrs_stream(vrs_path, stream_id, label)
+    tmp_h265: Path = Path(tempfile.mktemp(suffix=".h265"))
+    timestamps_ns: list[int] = _stream_vrs_to_file(vrs_path, stream_id, label, tmp_h265)
     t_read: float = time.perf_counter() - t0
 
-    if not nal_units:
+    if not timestamps_ns:
         print(f"  [WARN] No frames in stream {stream_id}")
+        tmp_h265.unlink(missing_ok=True)
         return []
 
-    # Write Annex-B bitstream to temp file, transcode via ffmpeg
+    # Transcode via ffmpeg
     t1: float = time.perf_counter()
-    with tempfile.NamedTemporaryFile(suffix=".h265", delete=False) as tmp:
-        tmp.write(b"".join(nal_units))
-        tmp_path: Path = Path(tmp.name)
-
     ffmpeg_transcode(
-        input_path=tmp_path,
+        input_path=tmp_h265,
         output_path=output_path,
         input_format="hevc",
         fps=_fps_from_timestamps(timestamps_ns),
         encoder=encoder,
         cq=cq,
     )
-    tmp_path.unlink()
+    tmp_h265.unlink()
 
     t_transcode: float = time.perf_counter() - t1
     print(
-        f"  {label}: {len(nal_units)} frames → {output_path.name} "
+        f"  {label}: {len(timestamps_ns)} frames → {output_path.name} "
         f"[{encoder}, cq={cq}] ({t_read + t_transcode:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
     )
     return timestamps_ns

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -159,10 +159,16 @@ def transcode_h265_stream_to_mp4(
     out_stream.width = in_stream.codec_context.width
     out_stream.height = in_stream.codec_context.height
     out_stream.pix_fmt = in_stream.codec_context.pix_fmt or "gray"
+    # Force a fixed time_base so PTS increments are meaningful.
+    out_stream.time_base = Fraction(1, fps)
 
     frame_count: int = 0
     for frame in tqdm(inp.decode(in_stream), total=len(nal_units), desc=f"Transcode {label}", leave=False):
+        # Decoded frames from raw Annex-B have pts=None.  Assign monotonic
+        # PTS in units of (1/fps) so each frame advances by exactly 1 tick.
         frame.pts = frame_count
+        frame.dts = frame_count
+        frame.time_base = Fraction(1, fps)
         for packet in out_stream.encode(frame):
             out.mux(packet)
         frame_count += 1

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -14,15 +14,12 @@ Usage:
 
 from __future__ import annotations
 
-import io
 import json
 import shutil
 import time
 from dataclasses import dataclass, field
-from fractions import Fraction
 from pathlib import Path
 
-import av
 import pyvrs
 from tqdm import tqdm
 
@@ -101,23 +98,53 @@ def _get_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
     raise ValueError(f"Could not determine dimensions for stream {stream_id}")
 
 
-def remux_h265_stream_to_mp4(
+def _ffmpeg_available() -> bool:
+    """Check if ffmpeg is on PATH."""
+    import shutil
+
+    return shutil.which("ffmpeg") is not None
+
+
+# Encoder preference: NVENC GPU first, then CPU fallback.
+_FFMPEG_ENCODER_CANDIDATES: list[str] = ["hevc_nvenc", "libx265"]
+
+
+def _pick_ffmpeg_encoder() -> str:
+    """Return the first available ffmpeg H.265 encoder."""
+    import subprocess
+
+    for enc in _FFMPEG_ENCODER_CANDIDATES:
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-encoders"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if enc in result.stdout:
+            return enc
+    return "libx265"
+
+
+def transcode_h265_stream_to_mp4(
     vrs_path: Path,
     stream_id: str,
     output_path: Path,
 ) -> list[int]:
-    """Extract H.265 NAL units from VRS and remux to MP4 (no decode/encode).
+    """Extract H.265 NAL units from VRS and transcode to yuv420p H.265 MP4.
 
-    Approach (following the ``mux_h264_to_mp4`` pattern in rerun_log_utils):
-    1. Read raw H.265 Annex-B NAL units from VRS image blocks
-    2. Concatenate into a single bytestream, open as raw HEVC input
-    3. Demux packets and remux into MP4 with VRS device-time timestamps
+    The VRS stores monochrome (gray8) H.265 which Rerun cannot decode
+    (H.265 Rext profile). This function converts gray → yuv420p Main
+    profile via ffmpeg subprocess with NVENC GPU acceleration (~3s per
+    10k-frame SLAM stream).
 
-    This is ~130x faster than a full transcode since no decode or encode
-    occurs — packets are copied directly from VRS to MP4.
+    Approach:
+    1. Read raw H.265 Annex-B NAL units + timestamps from VRS
+    2. Write concatenated bitstream to temp file
+    3. Run ``ffmpeg -f hevc -i tmp.h265 -c:v hevc_nvenc -pix_fmt yuv420p out.mp4``
 
     Returns list of VRS timestamps in nanoseconds.
     """
+    import subprocess
+    import tempfile
+
     reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
     label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
     info: dict = reader.get_stream_info(stream_id)
@@ -138,39 +165,39 @@ def remux_h265_stream_to_mp4(
         print(f"  [WARN] No frames in stream {stream_id}")
         return []
 
-    # Phase 2: Remux — concatenate NAL units, open as raw HEVC, copy packets
+    # Phase 2: Write Annex-B bitstream to temp file
+    tmp_h265 = tempfile.NamedTemporaryFile(suffix=".h265", delete=False)
+    tmp_h265.write(b"".join(nal_units))
+    tmp_h265.close()
+    tmp_path: str = tmp_h265.name
+
+    # Phase 3: ffmpeg transcode gray H.265 → yuv420p H.265 MP4
     t1: float = time.perf_counter()
-    sample_bytes: io.BytesIO = io.BytesIO(b"".join(nal_units))
+    if len(timestamps_ns) > 1:
+        dt_ns: float = float(timestamps_ns[-1] - timestamps_ns[0]) / (len(timestamps_ns) - 1)
+        fps: int = max(1, round(1e9 / dt_ns))
+    else:
+        fps = 30
 
-    input_container = av.open(sample_bytes, mode="r", format="hevc")
-    input_stream = input_container.streams.video[0]
+    encoder: str = _pick_ffmpeg_encoder()
+    cmd: list[str] = [
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+        "-f", "hevc", "-i", tmp_path,
+        "-c:v", encoder, "-pix_fmt", "yuv420p",
+        "-r", str(fps),
+        str(output_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    Path(tmp_path).unlink()
 
-    output_container = av.open(str(output_path), mode="w")
-    output_stream = output_container.add_stream_from_template(input_stream)
-    # Nanosecond time_base preserves exact VRS timestamps without fps rounding.
-    ns_time_base: Fraction = Fraction(1, 1_000_000_000)
-    output_stream.time_base = ns_time_base
-    if output_stream.codec_context is not None:
-        output_stream.codec_context.time_base = ns_time_base
+    if result.returncode:
+        raise RuntimeError(f"ffmpeg failed for {label}: {result.stderr[-300:]}")
 
-    start_ns: int = timestamps_ns[0]
-    frame_count: int = 0
-    for packet, ts_ns in zip(input_container.demux(input_stream), timestamps_ns, strict=False):
-        packet.time_base = ns_time_base
-        packet.pts = ts_ns - start_ns
-        packet.dts = packet.pts  # No B-frames in VRS H.265 (all I-frames)
-        packet.stream = output_stream
-        output_container.mux(packet)
-        frame_count += 1
-
-    input_container.close()
-    output_container.close()
-
-    t_remux: float = time.perf_counter() - t1
-    t_total: float = t_read + t_remux
+    t_transcode: float = time.perf_counter() - t1
+    t_total: float = t_read + t_transcode
     print(
-        f"  {label}: {frame_count} frames → {output_path.name} "
-        f"({t_total:.1f}s: read {t_read:.1f}s, remux {t_remux:.1f}s)"
+        f"  {label}: {len(nal_units)} frames → {output_path.name} "
+        f"[{encoder}] ({t_total:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
     )
     return timestamps_ns
 
@@ -249,8 +276,8 @@ def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
                 print(f"  {label}: copied preview MP4 ({preview.name}), {len(timestamps)} VRS timestamps")
                 continue
 
-        # SLAM cameras (or RGB fallback): H.265 remux from VRS (no decode/encode)
-        timestamps = remux_h265_stream_to_mp4(
+        # SLAM cameras (or RGB fallback): gray H.265 → yuv420p via ffmpeg+NVENC
+        timestamps = transcode_h265_stream_to_mp4(
             vrs_path=vrs_path,
             stream_id=stream_id,
             output_path=output_path,

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -25,7 +25,7 @@ import pyvrs
 from tqdm import tqdm
 
 from simplecv.data.hot3d_utils import (
-    Hot3dSequenceCalibration,
+    AriaSequenceCalibration,
     parse_online_calibration_first,
     save_calibration,
 )
@@ -201,7 +201,7 @@ def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
         print("  [WARN] No online_calibration.jsonl found, skipping")
         return
 
-    cal: Hot3dSequenceCalibration = parse_online_calibration_first(cal_jsonl)
+    cal: AriaSequenceCalibration = parse_online_calibration_first(cal_jsonl)
     for sid in streams:
         label = ARIA_GEN2_STREAM_ID_TO_LABEL.get(sid, sid)
         try:

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -98,29 +98,26 @@ def _get_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
     raise ValueError(f"Could not determine dimensions for stream {stream_id}")
 
 
-def _ffmpeg_available() -> bool:
-    """Check if ffmpeg is on PATH."""
-    import shutil
-
-    return shutil.which("ffmpeg") is not None
-
-
-# Encoder preference: NVENC GPU first, then CPU fallback.
-_FFMPEG_ENCODER_CANDIDATES: list[str] = ["hevc_nvenc", "libx265"]
-
-
 def _pick_ffmpeg_encoder() -> str:
-    """Return the first available ffmpeg H.265 encoder."""
+    """Return the best available ffmpeg AV1/H.265 encoder.
+
+    Prefers NVENC GPU (av1_nvenc > hevc_nvenc) then CPU fallback (libsvtav1).
+    Note: NVDEC (hevc_cuvid) is NOT used for decode because it cannot handle
+    raw Annex-B input (``-f hevc``). CPU H.265 decode is fast enough (~380fps
+    for 512x512).
+    """
     import subprocess
 
-    for enc in _FFMPEG_ENCODER_CANDIDATES:
-        result = subprocess.run(
-            ["ffmpeg", "-hide_banner", "-encoders"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if enc in result.stdout:
-            return enc
-    return "libx265"
+    result = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-encoders"],
+        capture_output=True, text=True, timeout=10,
+    )
+    encoders: str = result.stdout
+
+    for candidate in ["av1_nvenc", "hevc_nvenc"]:
+        if candidate in encoders:
+            return candidate
+    return "libsvtav1"
 
 
 def transcode_h265_stream_to_mp4(
@@ -128,17 +125,16 @@ def transcode_h265_stream_to_mp4(
     stream_id: str,
     output_path: Path,
 ) -> list[int]:
-    """Extract H.265 NAL units from VRS and transcode to yuv420p H.265 MP4.
+    """Extract H.265 NAL units from VRS and transcode to yuv420p AV1 MP4.
 
     The VRS stores monochrome (gray8) H.265 which Rerun cannot decode
-    (H.265 Rext profile). This function converts gray → yuv420p Main
-    profile via ffmpeg subprocess with NVENC GPU acceleration (~3s per
-    10k-frame SLAM stream).
+    (H.265 Rext profile). This function converts gray → yuv420p AV1
+    via ffmpeg with full GPU pipeline: NVDEC decode + NVENC AV1 encode.
 
     Approach:
     1. Read raw H.265 Annex-B NAL units + timestamps from VRS
     2. Write concatenated bitstream to temp file
-    3. Run ``ffmpeg -f hevc -i tmp.h265 -c:v hevc_nvenc -pix_fmt yuv420p out.mp4``
+    3. Run ``ffmpeg -c:v hevc_cuvid -i tmp.h265 -c:v av1_nvenc -pix_fmt yuv420p out.mp4``
 
     Returns list of VRS timestamps in nanoseconds.
     """
@@ -171,7 +167,7 @@ def transcode_h265_stream_to_mp4(
     tmp_h265.close()
     tmp_path: str = tmp_h265.name
 
-    # Phase 3: ffmpeg transcode gray H.265 → yuv420p H.265 MP4
+    # Phase 3: ffmpeg GPU transcode gray H.265 → yuv420p AV1 MP4
     t1: float = time.perf_counter()
     if len(timestamps_ns) > 1:
         dt_ns: float = float(timestamps_ns[-1] - timestamps_ns[0]) / (len(timestamps_ns) - 1)

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -1,11 +1,12 @@
-"""One-time VRS → MP4 conversion for Aria Gen2 Pilot sequences.
+"""One-time VRS → AV1 MP4 conversion for Aria Gen2 Pilot sequences.
 
 Aria Gen2 encodes video streams as H.265 inside VRS (unlike Gen1 which uses
-JPEG). This script extracts H.265 NAL units from VRS and **remuxes** them
-into MP4 containers without decode/encode — ~130x faster than transcoding.
+JPEG). The SLAM cameras use monochrome (gray8) H.265 Rext profile which
+neither Rerun nor NVDEC can decode, so we transcode to yuv420p AV1 via
+ffmpeg + NVENC (~4s per 10k-frame stream).
 
-For the RGB stream, the download provides a preview MP4 which is used directly
-(just copied + timestamps extracted from VRS).
+For the RGB stream, the download provides a preview MP4 which is copied
+directly (timestamps still extracted from VRS for pose alignment).
 
 Usage:
     pixi run preprocess-aria-gen2-pilot --root /mnt/8tb/data/aria-gen2-pilot
@@ -16,6 +17,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,10 +27,10 @@ from tqdm import tqdm
 
 from simplecv.data.hot3d_utils import (
     Hot3dSequenceCalibration,
-    Hot3dStreamCalibration,
     parse_online_calibration_first,
     save_calibration,
 )
+from simplecv.video_encoder import ffmpeg_transcode, pick_ffmpeg_encoder
 
 # ── Aria Gen2 stream mapping ──────────────────────────────────────────── #
 # Gen2 has 5 cameras vs Gen1's 3, with different SLAM camera labels.
@@ -49,7 +51,6 @@ ARIA_GEN2_STREAM_LABEL_TO_FILENAME: dict[str, str] = {
     "slam-side-right": "slam_side_right.mp4",
 }
 
-# Default streams to extract
 ARIA_GEN2_STREAM_IDS: list[str] = ["214-1", "1201-1", "1201-2", "1201-3", "1201-4"]
 
 OUTPUT_DIR_NAME: str = "_simplecv"
@@ -70,24 +71,36 @@ class PreprocessConfig:
     """VRS stream IDs to extract. Empty = default Aria Gen2 streams."""
 
 
-def _extract_vrs_timestamps(vrs_path: Path, stream_id: str) -> list[int]:
-    """Read VRS timestamps for a stream without decoding images.
+# ── VRS helpers ───────────────────────────────────────────────────────── #
 
-    Returns list of nanosecond timestamps in device-time domain.
-    """
+
+def _read_vrs_stream(
+    vrs_path: Path, stream_id: str, label: str,
+) -> tuple[list[bytes], list[int]]:
+    """Read raw image blocks + nanosecond timestamps from a VRS stream."""
+    reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
+    info: dict = reader.get_stream_info(stream_id)
+    n_frames: int = info["data_records_count"]
+    filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
+
+    image_blocks: list[bytes] = []
+    timestamps_ns: list[int] = []
+    for rec in tqdm(filtered, total=n_frames, desc=f"Reading {label}", leave=False):
+        if rec.n_image_blocks > 0:
+            image_blocks.append(rec.image_blocks[0].tobytes())
+            timestamps_ns.append(int(rec.timestamp * 1e9))
+    return image_blocks, timestamps_ns
+
+
+def _extract_vrs_timestamps(vrs_path: Path, stream_id: str) -> list[int]:
+    """Read VRS timestamps for a stream without reading image data."""
     reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
     filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
-    timestamps_ns: list[int] = []
-    for rec in filtered:
-        timestamps_ns.append(int(rec.timestamp * 1e9))
-    return timestamps_ns
+    return [int(rec.timestamp * 1e9) for rec in filtered]
 
 
-def _get_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
-    """Read image dimensions from VRS stream image_spec.
-
-    Returns (width, height).
-    """
+def _get_vrs_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
+    """Read image (width, height) from VRS stream image_spec."""
     reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
     filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
     for rec in filtered:
@@ -98,110 +111,60 @@ def _get_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
     raise ValueError(f"Could not determine dimensions for stream {stream_id}")
 
 
-def _pick_ffmpeg_encoder() -> str:
-    """Return the best available ffmpeg AV1/H.265 encoder.
+# ── Stream processing ─────────────────────────────────────────────────── #
 
-    Prefers NVENC GPU (av1_nvenc > hevc_nvenc) then CPU fallback (libsvtav1).
-    Note: NVDEC (hevc_cuvid) is NOT used for decode because it cannot handle
-    raw Annex-B input (``-f hevc``). CPU H.265 decode is fast enough (~380fps
-    for 512x512).
-    """
-    import subprocess
 
-    result = subprocess.run(
-        ["ffmpeg", "-hide_banner", "-encoders"],
-        capture_output=True, text=True, timeout=10,
-    )
-    encoders: str = result.stdout
-
-    for candidate in ["av1_nvenc", "hevc_nvenc"]:
-        if candidate in encoders:
-            return candidate
-    return "libsvtav1"
+def _fps_from_timestamps(timestamps_ns: list[int]) -> int:
+    """Compute integer FPS from nanosecond timestamps."""
+    if len(timestamps_ns) > 1:
+        dt_ns: float = float(timestamps_ns[-1] - timestamps_ns[0]) / (len(timestamps_ns) - 1)
+        return max(1, round(1e9 / dt_ns))
+    return 30
 
 
 def transcode_h265_stream_to_mp4(
     vrs_path: Path,
     stream_id: str,
     output_path: Path,
+    encoder: str,
 ) -> list[int]:
     """Extract H.265 NAL units from VRS and transcode to yuv420p AV1 MP4.
 
     The VRS stores monochrome (gray8) H.265 which Rerun cannot decode
     (H.265 Rext profile) and NVDEC cannot decode (no Rext support).
-    CPU H.265 decode is required (~380fps for 512x512), then NVENC AV1
-    encode with HOT3D-matching settings (2Mbps, GOP=30, no B-frames).
-
-    Approach:
-    1. Read raw H.265 Annex-B NAL units + timestamps from VRS
-    2. Write concatenated bitstream to temp file
-    3. Run ``ffmpeg -f hevc -i tmp.h265 -c:v av1_nvenc -b:v 2M out.mp4``
+    CPU H.265 decode + NVENC AV1 encode via :func:`ffmpeg_transcode`.
 
     Returns list of VRS timestamps in nanoseconds.
     """
-    import subprocess
-    import tempfile
-
-    reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
     label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
-    info: dict = reader.get_stream_info(stream_id)
-    n_frames: int = info["data_records_count"]
 
-    # Phase 1: Read raw H.265 NAL units + timestamps from VRS
     t0: float = time.perf_counter()
-    filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
-    nal_units: list[bytes] = []
-    timestamps_ns: list[int] = []
-    for rec in tqdm(filtered, total=n_frames, desc=f"Reading {label}", leave=False):
-        if rec.n_image_blocks > 0:
-            nal_units.append(rec.image_blocks[0].tobytes())
-            timestamps_ns.append(int(rec.timestamp * 1e9))
+    nal_units, timestamps_ns = _read_vrs_stream(vrs_path, stream_id, label)
     t_read: float = time.perf_counter() - t0
 
     if not nal_units:
         print(f"  [WARN] No frames in stream {stream_id}")
         return []
 
-    # Phase 2: Write Annex-B bitstream to temp file
-    tmp_h265 = tempfile.NamedTemporaryFile(suffix=".h265", delete=False)
-    tmp_h265.write(b"".join(nal_units))
-    tmp_h265.close()
-    tmp_path: str = tmp_h265.name
-
-    # Phase 3: ffmpeg GPU transcode gray H.265 → yuv420p AV1 MP4
+    # Write Annex-B bitstream to temp file, transcode via ffmpeg
     t1: float = time.perf_counter()
-    if len(timestamps_ns) > 1:
-        dt_ns: float = float(timestamps_ns[-1] - timestamps_ns[0]) / (len(timestamps_ns) - 1)
-        fps: int = max(1, round(1e9 / dt_ns))
-    else:
-        fps = 30
+    with tempfile.NamedTemporaryFile(suffix=".h265", delete=False) as tmp:
+        tmp.write(b"".join(nal_units))
+        tmp_path: Path = Path(tmp.name)
 
-    encoder: str = _pick_ffmpeg_encoder()
-    # GOP=30 (1s keyframes at 30fps), no B-frames — consistent with HOT3D.
-    # NVENC: use default quality (CQ mode); ffmpeg NVENC defaults are sane
-    # unlike PyAV's container.add_stream() which defaults to unlimited bitrate.
-    # CPU fallback: CRF 30, preset 8 matching video_encoder.py settings.
-    encoder_args: list[str] = ["-c:v", encoder, "-pix_fmt", "yuv420p", "-g", "30", "-bf", "0"]
-    if encoder == "libsvtav1":
-        encoder_args += ["-crf", "30", "-preset", "8"]
-    cmd: list[str] = [
-        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
-        "-f", "hevc", "-i", tmp_path,
-        *encoder_args,
-        "-r", str(fps),
-        str(output_path),
-    ]
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
-    Path(tmp_path).unlink()
-
-    if result.returncode:
-        raise RuntimeError(f"ffmpeg failed for {label}: {result.stderr[-300:]}")
+    ffmpeg_transcode(
+        input_path=tmp_path,
+        output_path=output_path,
+        input_format="hevc",
+        fps=_fps_from_timestamps(timestamps_ns),
+        encoder=encoder,
+    )
+    tmp_path.unlink()
 
     t_transcode: float = time.perf_counter() - t1
-    t_total: float = t_read + t_transcode
     print(
         f"  {label}: {len(nal_units)} frames → {output_path.name} "
-        f"[{encoder}] ({t_total:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
+        f"[{encoder}] ({t_read + t_transcode:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
     )
     return timestamps_ns
 
@@ -209,9 +172,10 @@ def transcode_h265_stream_to_mp4(
 def _find_preview_mp4(seq_dir: Path) -> Path | None:
     """Find the preview RGB MP4 downloaded alongside the VRS."""
     candidates: list[Path] = list(seq_dir.glob("*_preview_rgb.mp4"))
-    if candidates:
-        return candidates[0]
-    return None
+    return candidates[0] if candidates else None
+
+
+# ── Sequence-level orchestration ──────────────────────────────────────── #
 
 
 def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
@@ -237,63 +201,51 @@ def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
     t_seq_start: float = time.perf_counter()
     print(f"  Streams: {streams}")
 
-    # ── Extract calibration with correct dimensions ──────────────────────
+    # ── Calibration (patch dimensions from VRS image specs) ───────────────
     cal_jsonl: Path = seq_dir / "mps" / "slam" / "online_calibration.jsonl"
     if not cal_jsonl.exists():
         print("  [WARN] No online_calibration.jsonl found, skipping")
         return
 
     cal: Hot3dSequenceCalibration = parse_online_calibration_first(cal_jsonl)
-
-    # Fix image dimensions from VRS (online_calibration uses approximate cx*2/cy*2)
-    vrs_dims: dict[str, tuple[int, int]] = {}
     for sid in streams:
-        label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(sid, sid)
+        label = ARIA_GEN2_STREAM_ID_TO_LABEL.get(sid, sid)
         try:
-            w, h = _get_stream_dimensions(vrs_path, sid)
-            vrs_dims[label] = (w, h)
+            w, h = _get_vrs_stream_dimensions(vrs_path, sid)
         except ValueError:
-            pass
-
-    for stream_cal in cal.streams:
-        if stream_cal.stream_label in vrs_dims:
-            stream_cal.width, stream_cal.height = vrs_dims[stream_cal.stream_label]
+            continue
+        for stream_cal in cal.streams:
+            if stream_cal.stream_label == label:
+                stream_cal.width, stream_cal.height = w, h
 
     save_calibration(cal, output_dir / "calibration.json")
     print(f"  Calibration: {len(cal.streams)} streams, dims patched from VRS")
 
-    # ── Extract video streams ─────────────────────────────────────────────
+    # ── Video streams ─────────────────────────────────────────────────────
+    encoder: str = pick_ffmpeg_encoder()
     all_timestamps: dict[str, list[int]] = {}
 
     for stream_id in streams:
-        label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
+        label = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
         filename: str = ARIA_GEN2_STREAM_LABEL_TO_FILENAME.get(label, f"{label}.mp4")
         output_path: Path = output_dir / filename
 
         if label == "camera-rgb":
-            # RGB: use preview MP4 if available (much faster than VRS transcode)
             preview: Path | None = _find_preview_mp4(seq_dir)
             if preview is not None:
                 shutil.copy2(str(preview), str(output_path))
-                timestamps: list[int] = _extract_vrs_timestamps(vrs_path, stream_id)
-                all_timestamps[label] = timestamps
-                print(f"  {label}: copied preview MP4 ({preview.name}), {len(timestamps)} VRS timestamps")
+                all_timestamps[label] = _extract_vrs_timestamps(vrs_path, stream_id)
+                print(f"  {label}: copied preview MP4 ({preview.name}), {len(all_timestamps[label])} VRS timestamps")
                 continue
 
-        # SLAM cameras (or RGB fallback): gray H.265 → yuv420p via ffmpeg+NVENC
-        timestamps = transcode_h265_stream_to_mp4(
-            vrs_path=vrs_path,
-            stream_id=stream_id,
-            output_path=output_path,
+        all_timestamps[label] = transcode_h265_stream_to_mp4(
+            vrs_path=vrs_path, stream_id=stream_id, output_path=output_path, encoder=encoder,
         )
-        all_timestamps[label] = timestamps
 
-    # Save timestamps
-    ts_path: Path = output_dir / "timestamps_ns.json"
-    ts_path.write_text(json.dumps(all_timestamps))
+    # ── Save timestamps ───────────────────────────────────────────────────
+    (output_dir / "timestamps_ns.json").write_text(json.dumps(all_timestamps))
 
-    t_seq_elapsed: float = time.perf_counter() - t_seq_start
-    print(f"  Done in {t_seq_elapsed:.1f}s ({len(streams)} streams)")
+    print(f"  Done in {time.perf_counter() - t_seq_start:.1f}s ({len(streams)} streams)")
 
 
 def main(config: PreprocessConfig) -> None:

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -16,7 +16,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import shutil
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -92,13 +91,6 @@ def _read_vrs_stream(
     return image_blocks, timestamps_ns
 
 
-def _extract_vrs_timestamps(vrs_path: Path, stream_id: str) -> list[int]:
-    """Read VRS timestamps for a stream without reading image data."""
-    reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
-    filtered = reader.filtered_by_fields(stream_ids=stream_id, record_types="data")
-    return [int(rec.timestamp * 1e9) for rec in filtered]
-
-
 def _get_vrs_stream_dimensions(vrs_path: Path, stream_id: str) -> tuple[int, int]:
     """Read image (width, height) from VRS stream image_spec."""
     reader: pyvrs.SyncVRSReader = pyvrs.SyncVRSReader(str(vrs_path))
@@ -122,6 +114,12 @@ def _fps_from_timestamps(timestamps_ns: list[int]) -> int:
     return 30
 
 
+# NVENC CQ for SLAM streams (512x512 grayscale).  Higher = smaller file.
+# SLAM frames have low entropy; CQ 40 gives ~17MB vs ~85MB at NVENC default.
+# RGB uses None (NVENC default) which already produces good quality at ~88MB.
+_CQ_SLAM: int = 40
+
+
 def transcode_h265_stream_to_mp4(
     vrs_path: Path,
     stream_id: str,
@@ -137,6 +135,7 @@ def transcode_h265_stream_to_mp4(
     Returns list of VRS timestamps in nanoseconds.
     """
     label: str = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
+    cq: int | None = None if label == "camera-rgb" else _CQ_SLAM
 
     t0: float = time.perf_counter()
     nal_units, timestamps_ns = _read_vrs_stream(vrs_path, stream_id, label)
@@ -158,21 +157,16 @@ def transcode_h265_stream_to_mp4(
         input_format="hevc",
         fps=_fps_from_timestamps(timestamps_ns),
         encoder=encoder,
+        cq=cq,
     )
     tmp_path.unlink()
 
     t_transcode: float = time.perf_counter() - t1
     print(
         f"  {label}: {len(nal_units)} frames → {output_path.name} "
-        f"[{encoder}] ({t_read + t_transcode:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
+        f"[{encoder}, cq={cq}] ({t_read + t_transcode:.1f}s: read {t_read:.1f}s, transcode {t_transcode:.1f}s)"
     )
     return timestamps_ns
-
-
-def _find_preview_mp4(seq_dir: Path) -> Path | None:
-    """Find the preview RGB MP4 downloaded alongside the VRS."""
-    candidates: list[Path] = list(seq_dir.glob("*_preview_rgb.mp4"))
-    return candidates[0] if candidates else None
 
 
 # ── Sequence-level orchestration ──────────────────────────────────────── #
@@ -229,14 +223,6 @@ def preprocess_sequence(seq_dir: Path, config: PreprocessConfig) -> None:
         label = ARIA_GEN2_STREAM_ID_TO_LABEL.get(stream_id, stream_id)
         filename: str = ARIA_GEN2_STREAM_LABEL_TO_FILENAME.get(label, f"{label}.mp4")
         output_path: Path = output_dir / filename
-
-        if label == "camera-rgb":
-            preview: Path | None = _find_preview_mp4(seq_dir)
-            if preview is not None:
-                shutil.copy2(str(preview), str(output_path))
-                all_timestamps[label] = _extract_vrs_timestamps(vrs_path, stream_id)
-                print(f"  {label}: copied preview MP4 ({preview.name}), {len(all_timestamps[label])} VRS timestamps")
-                continue
 
         all_timestamps[label] = transcode_h265_stream_to_mp4(
             vrs_path=vrs_path, stream_id=stream_id, output_path=output_path, encoder=encoder,

--- a/simplecv/apis/preprocess_aria_gen2_pilot.py
+++ b/simplecv/apis/preprocess_aria_gen2_pilot.py
@@ -128,13 +128,14 @@ def transcode_h265_stream_to_mp4(
     """Extract H.265 NAL units from VRS and transcode to yuv420p AV1 MP4.
 
     The VRS stores monochrome (gray8) H.265 which Rerun cannot decode
-    (H.265 Rext profile). This function converts gray → yuv420p AV1
-    via ffmpeg with full GPU pipeline: NVDEC decode + NVENC AV1 encode.
+    (H.265 Rext profile) and NVDEC cannot decode (no Rext support).
+    CPU H.265 decode is required (~380fps for 512x512), then NVENC AV1
+    encode with HOT3D-matching settings (2Mbps, GOP=30, no B-frames).
 
     Approach:
     1. Read raw H.265 Annex-B NAL units + timestamps from VRS
     2. Write concatenated bitstream to temp file
-    3. Run ``ffmpeg -c:v hevc_cuvid -i tmp.h265 -c:v av1_nvenc -pix_fmt yuv420p out.mp4``
+    3. Run ``ffmpeg -f hevc -i tmp.h265 -c:v av1_nvenc -b:v 2M out.mp4``
 
     Returns list of VRS timestamps in nanoseconds.
     """
@@ -176,10 +177,17 @@ def transcode_h265_stream_to_mp4(
         fps = 30
 
     encoder: str = _pick_ffmpeg_encoder()
+    # GOP=30 (1s keyframes at 30fps), no B-frames — consistent with HOT3D.
+    # NVENC: use default quality (CQ mode); ffmpeg NVENC defaults are sane
+    # unlike PyAV's container.add_stream() which defaults to unlimited bitrate.
+    # CPU fallback: CRF 30, preset 8 matching video_encoder.py settings.
+    encoder_args: list[str] = ["-c:v", encoder, "-pix_fmt", "yuv420p", "-g", "30", "-bf", "0"]
+    if encoder == "libsvtav1":
+        encoder_args += ["-crf", "30", "-preset", "8"]
     cmd: list[str] = [
         "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
         "-f", "hevc", "-i", tmp_path,
-        "-c:v", encoder, "-pix_fmt", "yuv420p",
+        *encoder_args,
         "-r", str(fps),
         str(output_path),
     ]

--- a/simplecv/apis/view_exoego.py
+++ b/simplecv/apis/view_exoego.py
@@ -639,8 +639,21 @@ def log_exoego_batch(
             cam_log_path: Path = parent_log_path / "ego" / cam_name
             pinhole_log_path: Path = cam_log_path / "pinhole"
 
+            # When ego cameras run at different frame rates (e.g. RGB 10fps vs
+            # SLAM 30fps), camera params must be temporally aligned to label
+            # timestamps rather than indexed by raw frame number.
+            cam_stream_name: str = f"ego/{cam_name}"
+            cam_video_ts: Int[ndarray, "n_cam_frames"] | None = exoego_sequence.stream_timestamps_ns.get(cam_stream_name)
+            if cam_video_ts is not None and len(cam_video_ts) != len(label_timestamps_trim) and len(cam_video_ts) > 0:
+                # Different frame rate: for each label timestamp pick the nearest cam param
+                indices: Int[ndarray, "n_labels"] = np.searchsorted(cam_video_ts, label_timestamps_trim, side="right") - 1
+                indices = np.clip(indices, 0, len(ego_cam_param_list) - 1)
+                aligned_cam_params: list[PinholeParameters | Fisheye62Parameters] = [ego_cam_param_list[int(i)] for i in indices]
+            else:
+                aligned_cam_params = ego_cam_param_list
+
             # Align coordinate, confidence, and camera-parameter buffers when their lengths differ.
-            n_frames_total: int = min(len(xyz_stack), len(ego_cam_param_list))
+            n_frames_total: int = min(len(xyz_stack), len(aligned_cam_params))
             xyz_trim: Float[ndarray, "n_frames 133 3"] = xyz_stack[:n_frames_total]
             conf_trim: Float[ndarray, "n_frames 133"] = conf_stack[:n_frames_total]
             color_trim: UInt8[ndarray, "n_frames 133 3"] = colors[:n_frames_total]
@@ -648,10 +661,10 @@ def log_exoego_batch(
             if n_frames_total == 0:
                 continue
 
-            if isinstance(ego_cam_param_list[0], PinholeParameters):
+            if isinstance(aligned_cam_params[0], PinholeParameters):
                 # Time-aligned fast path: one call over the full trimmed sequence
                 pinhole_slice_full: list[PinholeParameters] = cast(
-                    list[PinholeParameters], ego_cam_param_list[:n_frames_total]
+                    list[PinholeParameters], aligned_cam_params[:n_frames_total]
                 )
                 uv_ego_stack: Float[ndarray, "n_frames 133 2"] = project_brown_conrady_diagonal(
                     xyz_stack_world=xyz_trim[:n_frames_total],
@@ -659,10 +672,10 @@ def log_exoego_batch(
                     filter_invalid=True,
                 )
 
-            elif isinstance(ego_cam_param_list[0], Fisheye62Parameters):
+            elif isinstance(aligned_cam_params[0], Fisheye62Parameters):
                 # Time-aligned fisheye fast path: one pose per frame, no outer-product grid
                 fisheye_slice_full: list[Fisheye62Parameters] = cast(
-                    list[Fisheye62Parameters], ego_cam_param_list[:n_frames_total]
+                    list[Fisheye62Parameters], aligned_cam_params[:n_frames_total]
                 )
                 uv_ego_stack: Float[ndarray, "n_frames 133 2"] = project_kannala_brandt_diagonal(
                     xyz_stack_world=xyz_trim[:n_frames_total],
@@ -671,7 +684,7 @@ def log_exoego_batch(
                 )
             else:
                 raise NotImplementedError(
-                    f"Ego camera parameters of type '{type(ego_cam_param_list[0])}' are not supported."
+                    f"Ego camera parameters of type '{type(aligned_cam_params[0])}' are not supported."
                 )
 
             n_frames_cam: int = len(uv_ego_stack)

--- a/simplecv/apis/view_exoego.py
+++ b/simplecv/apis/view_exoego.py
@@ -862,15 +862,22 @@ def setup_scene(
             ego_timestamp_list.append(ego_timestamps_ns)
         ego_video_log_paths = ego_video_log_path_list
 
+        # Build per-camera timestamp map so each camera's poses are logged
+        # on its own video timeline. Cameras may run at different rates
+        # (e.g. Aria Gen2: RGB 10fps vs SLAM 30fps).
+        ego_ts_by_name: dict[str, Int[ndarray, "n_frames"]] = dict(
+            zip(ego_video_names, ego_timestamp_list, strict=True)
+        )
+
         # log the ego cameras and their trajectories
-        shortest_ego_timestamp: Int[ndarray, "n_frames"] = _choose_shortest_timeline_by_duration(ego_timestamp_list)
         ego_cam_dict: dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]] = cast(
             dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]], ego_sequence.ego_cam_dict
         )
         for cam_name, ego_cam_param_list in ego_cam_dict.items():
             if not ego_cam_param_list:
                 continue
-            n_frames_cam: int = min(len(ego_cam_param_list), len(shortest_ego_timestamp))
+            cam_video_ts: Int[ndarray, "n_frames"] = ego_ts_by_name[cam_name]
+            n_frames_cam: int = min(len(ego_cam_param_list), len(cam_video_ts))
             if n_frames_cam <= 0:
                 continue
             trimmed_cam_params: list[PinholeParameters | Fisheye62Parameters] = ego_cam_param_list[:n_frames_cam]
@@ -897,7 +904,7 @@ def setup_scene(
             # camera extrinsics, there's no from_parent=True so need to send as world_x_cam
             rr.send_columns(
                 f"{cam_log_path}",
-                indexes=[rr.TimeColumn(timeline, duration=1e-9 * shortest_ego_timestamp[0 : len(batch_world_t_cam)])],
+                indexes=[rr.TimeColumn(timeline, duration=1e-9 * cam_video_ts[0 : len(batch_world_t_cam)])],
                 columns=[
                     *rr.Transform3D.columns(
                         translation=rearrange(batch_world_t_cam, "f d -> (f) d"),

--- a/simplecv/apis/view_exoego.py
+++ b/simplecv/apis/view_exoego.py
@@ -639,21 +639,8 @@ def log_exoego_batch(
             cam_log_path: Path = parent_log_path / "ego" / cam_name
             pinhole_log_path: Path = cam_log_path / "pinhole"
 
-            # When ego cameras run at different frame rates (e.g. RGB 10fps vs
-            # SLAM 30fps), camera params must be temporally aligned to label
-            # timestamps rather than indexed by raw frame number.
-            cam_stream_name: str = f"ego/{cam_name}"
-            cam_video_ts: Int[ndarray, "n_cam_frames"] | None = exoego_sequence.stream_timestamps_ns.get(cam_stream_name)
-            if cam_video_ts is not None and len(cam_video_ts) != len(label_timestamps_trim) and len(cam_video_ts) > 0:
-                # Different frame rate: for each label timestamp pick the nearest cam param
-                indices: Int[ndarray, "n_labels"] = np.searchsorted(cam_video_ts, label_timestamps_trim, side="right") - 1
-                indices = np.clip(indices, 0, len(ego_cam_param_list) - 1)
-                aligned_cam_params: list[PinholeParameters | Fisheye62Parameters] = [ego_cam_param_list[int(i)] for i in indices]
-            else:
-                aligned_cam_params = ego_cam_param_list
-
             # Align coordinate, confidence, and camera-parameter buffers when their lengths differ.
-            n_frames_total: int = min(len(xyz_stack), len(aligned_cam_params))
+            n_frames_total: int = min(len(xyz_stack), len(ego_cam_param_list))
             xyz_trim: Float[ndarray, "n_frames 133 3"] = xyz_stack[:n_frames_total]
             conf_trim: Float[ndarray, "n_frames 133"] = conf_stack[:n_frames_total]
             color_trim: UInt8[ndarray, "n_frames 133 3"] = colors[:n_frames_total]
@@ -661,10 +648,10 @@ def log_exoego_batch(
             if n_frames_total == 0:
                 continue
 
-            if isinstance(aligned_cam_params[0], PinholeParameters):
+            if isinstance(ego_cam_param_list[0], PinholeParameters):
                 # Time-aligned fast path: one call over the full trimmed sequence
                 pinhole_slice_full: list[PinholeParameters] = cast(
-                    list[PinholeParameters], aligned_cam_params[:n_frames_total]
+                    list[PinholeParameters], ego_cam_param_list[:n_frames_total]
                 )
                 uv_ego_stack: Float[ndarray, "n_frames 133 2"] = project_brown_conrady_diagonal(
                     xyz_stack_world=xyz_trim[:n_frames_total],
@@ -672,10 +659,10 @@ def log_exoego_batch(
                     filter_invalid=True,
                 )
 
-            elif isinstance(aligned_cam_params[0], Fisheye62Parameters):
+            elif isinstance(ego_cam_param_list[0], Fisheye62Parameters):
                 # Time-aligned fisheye fast path: one pose per frame, no outer-product grid
                 fisheye_slice_full: list[Fisheye62Parameters] = cast(
-                    list[Fisheye62Parameters], aligned_cam_params[:n_frames_total]
+                    list[Fisheye62Parameters], ego_cam_param_list[:n_frames_total]
                 )
                 uv_ego_stack: Float[ndarray, "n_frames 133 2"] = project_kannala_brandt_diagonal(
                     xyz_stack_world=xyz_trim[:n_frames_total],
@@ -684,7 +671,7 @@ def log_exoego_batch(
                 )
             else:
                 raise NotImplementedError(
-                    f"Ego camera parameters of type '{type(aligned_cam_params[0])}' are not supported."
+                    f"Ego camera parameters of type '{type(ego_cam_param_list[0])}' are not supported."
                 )
 
             n_frames_cam: int = len(uv_ego_stack)
@@ -875,22 +862,15 @@ def setup_scene(
             ego_timestamp_list.append(ego_timestamps_ns)
         ego_video_log_paths = ego_video_log_path_list
 
-        # Build per-camera timestamp map so each camera's poses are logged
-        # on its own video timeline. Cameras may run at different rates
-        # (e.g. Aria Gen2: RGB 10fps vs SLAM 30fps).
-        ego_ts_by_name: dict[str, Int[ndarray, "n_frames"]] = dict(
-            zip(ego_video_names, ego_timestamp_list, strict=True)
-        )
-
         # log the ego cameras and their trajectories
+        shortest_ego_timestamp: Int[ndarray, "n_frames"] = _choose_shortest_timeline_by_duration(ego_timestamp_list)
         ego_cam_dict: dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]] = cast(
             dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]], ego_sequence.ego_cam_dict
         )
         for cam_name, ego_cam_param_list in ego_cam_dict.items():
             if not ego_cam_param_list:
                 continue
-            cam_video_ts: Int[ndarray, "n_frames"] = ego_ts_by_name[cam_name]
-            n_frames_cam: int = min(len(ego_cam_param_list), len(cam_video_ts))
+            n_frames_cam: int = min(len(ego_cam_param_list), len(shortest_ego_timestamp))
             if n_frames_cam <= 0:
                 continue
             trimmed_cam_params: list[PinholeParameters | Fisheye62Parameters] = ego_cam_param_list[:n_frames_cam]
@@ -917,7 +897,7 @@ def setup_scene(
             # camera extrinsics, there's no from_parent=True so need to send as world_x_cam
             rr.send_columns(
                 f"{cam_log_path}",
-                indexes=[rr.TimeColumn(timeline, duration=1e-9 * cam_video_ts[0 : len(batch_world_t_cam)])],
+                indexes=[rr.TimeColumn(timeline, duration=1e-9 * shortest_ego_timestamp[0 : len(batch_world_t_cam)])],
                 columns=[
                     *rr.Transform3D.columns(
                         translation=rearrange(batch_world_t_cam, "f d -> (f) d"),

--- a/simplecv/configs/exoego_dataset_configs.py
+++ b/simplecv/configs/exoego_dataset_configs.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import tyro
 
+from simplecv.data.exoego.aria_gen2_pilot import AriaGen2PilotConfig
 from simplecv.data.exoego.assembly101 import Assembly101Config
 from simplecv.data.exoego.base_exoego import BaseExoEgoDatasetConfig
 from simplecv.data.exoego.ego100k import Egocentric100KConfig
@@ -16,6 +17,7 @@ from simplecv.data.exoego.umetrack import UmeTrackConfig
 
 # ───────────────────── registry → union ─────────────────── #
 dataset_defaults = {
+    "aria-gen2": AriaGen2PilotConfig(),
     "assembly101": Assembly101Config(),
     "ego100k": Egocentric100KConfig(),
     "hocap": HocapConfig(),

--- a/simplecv/data/ego/aria_gen2_pilot_ego.py
+++ b/simplecv/data/ego/aria_gen2_pilot_ego.py
@@ -81,8 +81,7 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
     def load_ego_cams(self) -> dict[str, list[Fisheye62Parameters]]:
         """Load per-frame fisheye camera parameters for all ego cameras.
 
-        Calibration: prefer online_calibration.jsonl (MPS-refined), fall back
-        to camera_models.json.
+        Calibration: online_calibration.jsonl (MPS-refined).
         Trajectory: MPS closed_loop_trajectory.csv (device-time domain, 1kHz).
         """
         seq_dir: Path = self._sequence_dir()

--- a/simplecv/data/ego/aria_gen2_pilot_ego.py
+++ b/simplecv/data/ego/aria_gen2_pilot_ego.py
@@ -101,10 +101,14 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
         vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())
 
         # Use RGB timestamps as the canonical reference for ALL cameras.
-        # Gen2 cameras run at different rates (RGB 10fps, SLAM 30fps), but
-        # the viewer assumes all ego cameras share the same frame count.
+        # Gen2 cameras run at different rates (RGB 10fps, SLAM 30fps;
+        # hand tracking 30fps; SLAM trajectory 1kHz), but the viewer
+        # assumes all ego cameras share the same frame count.
         # By looking up trajectory poses at RGB timestamps for every camera,
         # all cameras get identical frame counts and temporal alignment.
+        # TODO: support per-camera native frame rates so SLAM cameras and
+        # hand labels can run at their full 30fps instead of being
+        # downsampled to the RGB 10fps timeline.
         rgb_label: str = "camera-rgb"
         assert rgb_label in vrs_ts_data, f"No RGB timestamps in timestamps_ns.json"
         canonical_device_ts: Int64[ndarray, "n_frames"] = np.array(vrs_ts_data[rgb_label], dtype=np.int64)

--- a/simplecv/data/ego/aria_gen2_pilot_ego.py
+++ b/simplecv/data/ego/aria_gen2_pilot_ego.py
@@ -101,14 +101,16 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
         vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())
 
         # Use RGB timestamps as the canonical reference for ALL cameras.
-        # Gen2 cameras run at different rates (RGB 10fps, SLAM 30fps;
-        # hand tracking 30fps; SLAM trajectory 1kHz), but the viewer
-        # assumes all ego cameras share the same frame count.
-        # By looking up trajectory poses at RGB timestamps for every camera,
-        # all cameras get identical frame counts and temporal alignment.
-        # TODO: support per-camera native frame rates so SLAM cameras and
-        # hand labels can run at their full 30fps instead of being
-        # downsampled to the RGB 10fps timeline.
+        # Native rates: RGB 10fps, SLAM cameras 30fps, hand tracking 30fps,
+        # SLAM trajectory 1kHz.  The SLAM *videos* play at their native
+        # 30fps, but camera *poses* are sampled at the RGB 10fps rate
+        # because the viewer assumes all ego cameras share the same frame
+        # count.  By looking up trajectory poses at RGB timestamps for
+        # every camera, all cameras get identical frame counts and
+        # temporal alignment.
+        # TODO: support per-stream native frame rates so SLAM camera poses,
+        # SLAM video frames, and hand labels all run at their full 30fps
+        # instead of being downsampled to the RGB 10fps timeline.
         rgb_label: str = "camera-rgb"
         assert rgb_label in vrs_ts_data, f"No RGB timestamps in timestamps_ns.json"
         canonical_device_ts: Int64[ndarray, "n_frames"] = np.array(vrs_ts_data[rgb_label], dtype=np.int64)

--- a/simplecv/data/ego/aria_gen2_pilot_ego.py
+++ b/simplecv/data/ego/aria_gen2_pilot_ego.py
@@ -7,6 +7,7 @@ Reuses HOT3D calibration and trajectory parsers since the MPS format is identica
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,8 +18,8 @@ from numpy import ndarray
 from simplecv.camera_parameters import Extrinsics, Fisheye62Parameters, Intrinsics, KannalaBrandtDistortion
 from simplecv.data.ego.base_ego import BaseEgoSequence, EgoData
 from simplecv.data.hot3d_utils import (
-    Hot3dSequenceCalibration,
-    Hot3dStreamCalibration,
+    AriaSequenceCalibration,
+    AriaStreamCalibration,
     load_calibration,
     lookup_nearest_poses,
     parse_mps_closed_loop_trajectory,
@@ -87,13 +88,13 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
         seq_dir: Path = self._sequence_dir()
 
         # Load calibration
-        cal: Hot3dSequenceCalibration = self._load_calibration(seq_dir)
-        cal_by_label: dict[str, Hot3dStreamCalibration] = {s.stream_label: s for s in cal.streams}
+        cal: AriaSequenceCalibration = self._load_calibration(seq_dir)
+        cal_by_label: dict[str, AriaStreamCalibration] = {s.stream_label: s for s in cal.streams}
 
         # Load trajectory
-        traj_ts_ns: Int64[ndarray, "n_poses"]
-        world_T_device_all: Float32[ndarray, "n_poses 4 4"]
-        traj_ts_ns, world_T_device_all = self._load_trajectory(seq_dir)
+        traj_result: tuple[Int64[ndarray, "n_poses"], Float32[ndarray, "n_poses 4 4"]] = self._load_trajectory(seq_dir)
+        traj_ts_ns: Int64[ndarray, "n_poses"] = traj_result[0]
+        world_T_device_all: Float32[ndarray, "n_poses 4 4"] = traj_result[1]
 
         # Load VRS device-time timestamps per stream
         vrs_ts_path: Path = seq_dir / SIMPLECV_DIR / "timestamps_ns.json"
@@ -126,7 +127,7 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
         all_cam_dict: dict[str, list[Fisheye62Parameters]] = {}
 
         for label in self._ego_streams:
-            stream_cal: Hot3dStreamCalibration | None = cal_by_label.get(label)
+            stream_cal: AriaStreamCalibration | None = cal_by_label.get(label)
             assert stream_cal is not None, f"No calibration found for stream '{label}'"
 
             device_T_camera: Float32[ndarray, "4 4"] = np.array(stream_cal.device_T_camera, dtype=np.float32)
@@ -156,11 +157,21 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
                 try:
                     cam_T_world: Float32[ndarray, "4 4"] = np.linalg.inv(world_T_camera)
                 except np.linalg.LinAlgError:
+                    warnings.warn(
+                        f"Singular world_T_camera for '{label}' at frame {frame_idx}, "
+                        f"reusing previous pose.",
+                        stacklevel=2,
+                    )
                     cam_T_world = prev_cam_T_world
                 else:
                     if np.all(np.isfinite(cam_T_world)):
                         prev_cam_T_world = cam_T_world
                     else:
+                        warnings.warn(
+                            f"Non-finite cam_T_world for '{label}' at frame {frame_idx}, "
+                            f"reusing previous pose.",
+                            stacklevel=2,
+                        )
                         cam_T_world = prev_cam_T_world
 
                 extrinsics: Extrinsics = Extrinsics(
@@ -175,7 +186,7 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
 
         return all_cam_dict
 
-    def _load_calibration(self, seq_dir: Path) -> Hot3dSequenceCalibration:
+    def _load_calibration(self, seq_dir: Path) -> AriaSequenceCalibration:
         """Load calibration, preferring preprocessed cache with correct dimensions."""
         preprocessed: Path = seq_dir / SIMPLECV_DIR / "calibration.json"
         if preprocessed.exists():

--- a/simplecv/data/ego/aria_gen2_pilot_ego.py
+++ b/simplecv/data/ego/aria_gen2_pilot_ego.py
@@ -1,0 +1,216 @@
+"""Egocentric view loader for Aria Gen2 Pilot dataset.
+
+Aria Gen2 has 5 cameras (RGB + 4 SLAM) with different labels from Gen1.
+Reuses HOT3D calibration and trajectory parsers since the MPS format is identical.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from jaxtyping import Float32, Int64
+from numpy import ndarray
+
+from simplecv.camera_parameters import Extrinsics, Fisheye62Parameters, Intrinsics, KannalaBrandtDistortion
+from simplecv.data.ego.base_ego import BaseEgoSequence, EgoData
+from simplecv.data.hot3d_utils import (
+    Hot3dSequenceCalibration,
+    Hot3dStreamCalibration,
+    load_calibration,
+    lookup_nearest_poses,
+    parse_mps_closed_loop_trajectory,
+    parse_online_calibration_first,
+)
+
+if TYPE_CHECKING:
+    from simplecv.data.exoego.aria_gen2_pilot import AriaGen2PilotConfig
+else:  # pragma: no cover - runtime alias to avoid circular import
+    from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig as AriaGen2PilotConfig
+
+# Aria Gen2 ego camera streams: label → MP4 filename stem.
+# Gen2 has 4 SLAM cameras (front-left/right, side-left/right) instead of Gen1's 2.
+ARIA_GEN2_EGO_STREAMS: dict[str, str] = {
+    "camera-rgb": "rgb",
+    "slam-front-left": "slam_front_left",
+    "slam-front-right": "slam_front_right",
+    "slam-side-left": "slam_side_left",
+    "slam-side-right": "slam_side_right",
+}
+
+SIMPLECV_DIR: str = "_simplecv"
+
+
+class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
+    """Egocentric view loader for Aria Gen2 Pilot."""
+
+    def __init__(self, cfg: AriaGen2PilotConfig) -> None:
+        self._ego_streams: dict[str, str] = ARIA_GEN2_EGO_STREAMS
+        super().__init__(cfg)
+
+    def __len__(self) -> int:
+        assert len(self.ego_video_readers) > 0, "No videos found."
+        return len(self.ego_video_readers)
+
+    def __getitem__(self, idx: int) -> EgoData:
+        raise NotImplementedError("Aria Gen2 Pilot ego data loading not implemented yet.")
+
+    def _sequence_dir(self) -> Path:
+        return Path(self.config.base_directory) / self.config.sequence_name
+
+    def load_video_paths(self) -> list[Path]:
+        """Load paths to preprocessed AV1 MP4 videos for all ego cameras."""
+        seq_dir: Path = self._sequence_dir()
+        simplecv_dir: Path = seq_dir / SIMPLECV_DIR
+
+        video_paths: list[Path] = []
+        for label, stem in self._ego_streams.items():
+            video_path: Path = simplecv_dir / f"{stem}.mp4"
+            assert video_path.exists(), (
+                f"Preprocessed video for '{label}' not found at {video_path}. "
+                f"Run: pixi run preprocess-aria-gen2-pilot --root {self.config.base_directory} "
+                f"--sequence {self.config.sequence_name} --no-skip-existing"
+            )
+            video_paths.append(video_path)
+
+        return video_paths
+
+    def load_ego_cams(self) -> dict[str, list[Fisheye62Parameters]]:
+        """Load per-frame fisheye camera parameters for all ego cameras.
+
+        Calibration: prefer online_calibration.jsonl (MPS-refined), fall back
+        to camera_models.json.
+        Trajectory: MPS closed_loop_trajectory.csv (device-time domain, 1kHz).
+        """
+        seq_dir: Path = self._sequence_dir()
+
+        # Load calibration
+        cal: Hot3dSequenceCalibration = self._load_calibration(seq_dir)
+        cal_by_label: dict[str, Hot3dStreamCalibration] = {s.stream_label: s for s in cal.streams}
+
+        # Load trajectory
+        traj_ts_ns: Int64[ndarray, "n_poses"]
+        world_T_device_all: Float32[ndarray, "n_poses 4 4"]
+        traj_ts_ns, world_T_device_all = self._load_trajectory(seq_dir)
+
+        # Load VRS device-time timestamps per stream
+        vrs_ts_path: Path = seq_dir / SIMPLECV_DIR / "timestamps_ns.json"
+        assert vrs_ts_path.exists(), f"VRS timestamps not found at {vrs_ts_path}"
+        vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())
+
+        # Build per-frame camera params for each stream
+        all_cam_dict: dict[str, list[Fisheye62Parameters]] = {}
+
+        for label in self._ego_streams:
+            stream_cal: Hot3dStreamCalibration | None = cal_by_label.get(label)
+            assert stream_cal is not None, f"No calibration found for stream '{label}'"
+            assert label in vrs_ts_data, (
+                f"No timestamps for stream '{label}' in timestamps_ns.json. "
+                f"Re-run preprocessing: pixi run preprocess-aria-gen2-pilot "
+                f"--root {self.config.base_directory} "
+                f"--sequence {self.config.sequence_name} --no-skip-existing"
+            )
+
+            device_T_camera: Float32[ndarray, "4 4"] = np.array(stream_cal.device_T_camera, dtype=np.float32)
+            stream_device_ts: Int64[ndarray, "n_frames"] = np.array(vrs_ts_data[label], dtype=np.int64)
+            n_frames: int = len(stream_device_ts)
+
+            world_T_device_frames: Float32[ndarray, "n_frames 4 4"] = lookup_nearest_poses(
+                query_ts_ns=stream_device_ts,
+                trajectory_ts_ns=traj_ts_ns,
+                world_T_device=world_T_device_all,
+            )
+
+            intrinsics: Intrinsics = Intrinsics(
+                camera_conventions="RDF",
+                fl_x=stream_cal.fl_x,
+                fl_y=stream_cal.fl_y,
+                cx=stream_cal.cx,
+                cy=stream_cal.cy,
+                height=stream_cal.height,
+                width=stream_cal.width,
+            )
+            distortion: KannalaBrandtDistortion = KannalaBrandtDistortion(
+                k1=stream_cal.k1, k2=stream_cal.k2, k3=stream_cal.k3,
+                k4=stream_cal.k4, k5=stream_cal.k5, k6=stream_cal.k6,
+                p1=stream_cal.p1, p2=stream_cal.p2,
+            )
+
+            cam_list: list[Fisheye62Parameters] = []
+            prev_cam_T_world: Float32[ndarray, "4 4"] = np.eye(4, dtype=np.float32)
+
+            for frame_idx in range(n_frames):
+                world_T_device: Float32[ndarray, "4 4"] = world_T_device_frames[frame_idx]
+                world_T_camera: Float32[ndarray, "4 4"] = world_T_device @ device_T_camera
+
+                try:
+                    cam_T_world: Float32[ndarray, "4 4"] = np.linalg.inv(world_T_camera)
+                except np.linalg.LinAlgError:
+                    cam_T_world = prev_cam_T_world
+                else:
+                    if np.all(np.isfinite(cam_T_world)):
+                        prev_cam_T_world = cam_T_world
+                    else:
+                        cam_T_world = prev_cam_T_world
+
+                extrinsics: Extrinsics = Extrinsics(
+                    cam_R_world=cam_T_world[:3, :3],
+                    cam_t_world=cam_T_world[:3, 3],
+                )
+                cam_list.append(Fisheye62Parameters(
+                    name=label, intrinsics=intrinsics, distortion=distortion, extrinsics=extrinsics,
+                ))
+
+            all_cam_dict[label] = cam_list
+
+        return all_cam_dict
+
+    def _load_calibration(self, seq_dir: Path) -> Hot3dSequenceCalibration:
+        """Load calibration, preferring preprocessed cache with correct dimensions."""
+        preprocessed: Path = seq_dir / SIMPLECV_DIR / "calibration.json"
+        if preprocessed.exists():
+            return load_calibration(preprocessed)
+
+        online_cal: Path = seq_dir / "mps" / "slam" / "online_calibration.jsonl"
+        assert online_cal.exists(), f"No calibration source found in {seq_dir}"
+        return parse_online_calibration_first(online_cal)
+
+    def _load_trajectory(self, seq_dir: Path) -> tuple[Int64[ndarray, "n"], Float32[ndarray, "n 4 4"]]:
+        """Load MPS SLAM closed-loop trajectory (device-time domain, 1kHz)."""
+        mps_traj: Path = seq_dir / "mps" / "slam" / "closed_loop_trajectory.csv"
+        assert mps_traj.exists(), (
+            f"MPS trajectory not found at {mps_traj}. "
+            f"Ensure mps_slam_trajectories was downloaded."
+        )
+        mps_result: tuple[
+            Int64[ndarray, "n_poses"], Float32[ndarray, "n_poses 4 4"], Float32[ndarray, "n_poses"]
+        ] = parse_mps_closed_loop_trajectory(mps_traj)
+        ts_ns: Int64[ndarray, "n_poses"] = mps_result[0]
+        world_T_device: Float32[ndarray, "n_poses 4 4"] = mps_result[1]
+        return ts_ns, world_T_device
+
+    def align_cams_and_videos(
+        self, video_path_list: list[Path], ego_cam_dict: dict[str, list[Fisheye62Parameters]]
+    ) -> tuple[dict[str, list[Fisheye62Parameters]], dict[str, Path]]:
+        """Align cameras and videos by stream label order."""
+        stream_labels: list[str] = list(self._ego_streams.keys())
+        assert len(video_path_list) == len(stream_labels), (
+            f"Expected {len(stream_labels)} ego videos, got {len(video_path_list)}"
+        )
+
+        aligned_cam_dict: dict[str, list[Fisheye62Parameters]] = {}
+        aligned_video_map: dict[str, Path] = {}
+
+        for idx, label in enumerate(stream_labels):
+            assert label in ego_cam_dict, f"Camera '{label}' missing from ego camera dictionary"
+            aligned_cam_dict[label] = ego_cam_dict[label]
+            aligned_video_map[label] = video_path_list[idx]
+
+        return aligned_cam_dict, aligned_video_map
+
+    @property
+    def image_plane_distance(self) -> int | float:
+        """Image plane distance for camera visualization in meters."""
+        return 0.03

--- a/simplecv/data/ego/aria_gen2_pilot_ego.py
+++ b/simplecv/data/ego/aria_gen2_pilot_ego.py
@@ -100,28 +100,30 @@ class AriaGen2PilotEgoSequence(BaseEgoSequence[AriaGen2PilotConfig]):
         assert vrs_ts_path.exists(), f"VRS timestamps not found at {vrs_ts_path}"
         vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())
 
+        # Use RGB timestamps as the canonical reference for ALL cameras.
+        # Gen2 cameras run at different rates (RGB 10fps, SLAM 30fps), but
+        # the viewer assumes all ego cameras share the same frame count.
+        # By looking up trajectory poses at RGB timestamps for every camera,
+        # all cameras get identical frame counts and temporal alignment.
+        rgb_label: str = "camera-rgb"
+        assert rgb_label in vrs_ts_data, f"No RGB timestamps in timestamps_ns.json"
+        canonical_device_ts: Int64[ndarray, "n_frames"] = np.array(vrs_ts_data[rgb_label], dtype=np.int64)
+        n_frames: int = len(canonical_device_ts)
+
+        world_T_device_frames: Float32[ndarray, "n_frames 4 4"] = lookup_nearest_poses(
+            query_ts_ns=canonical_device_ts,
+            trajectory_ts_ns=traj_ts_ns,
+            world_T_device=world_T_device_all,
+        )
+
         # Build per-frame camera params for each stream
         all_cam_dict: dict[str, list[Fisheye62Parameters]] = {}
 
         for label in self._ego_streams:
             stream_cal: Hot3dStreamCalibration | None = cal_by_label.get(label)
             assert stream_cal is not None, f"No calibration found for stream '{label}'"
-            assert label in vrs_ts_data, (
-                f"No timestamps for stream '{label}' in timestamps_ns.json. "
-                f"Re-run preprocessing: pixi run preprocess-aria-gen2-pilot "
-                f"--root {self.config.base_directory} "
-                f"--sequence {self.config.sequence_name} --no-skip-existing"
-            )
 
             device_T_camera: Float32[ndarray, "4 4"] = np.array(stream_cal.device_T_camera, dtype=np.float32)
-            stream_device_ts: Int64[ndarray, "n_frames"] = np.array(vrs_ts_data[label], dtype=np.int64)
-            n_frames: int = len(stream_device_ts)
-
-            world_T_device_frames: Float32[ndarray, "n_frames 4 4"] = lookup_nearest_poses(
-                query_ts_ns=stream_device_ts,
-                trajectory_ts_ns=traj_ts_ns,
-                world_T_device=world_T_device_all,
-            )
 
             intrinsics: Intrinsics = Intrinsics(
                 camera_conventions="RDF",

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -1,20 +1,20 @@
 """Aria Gen2 Pilot dataset adapter for the ExoEgo visualization pipeline.
 
-Ego-only (Aria device, no exo cameras). Uses preprocessed AV1 MP4 videos
-(from VRS), MPS SLAM trajectories for camera poses. MPS hand tracking
-provides wrist+palm positions only (not full finger keypoints), so labels
-are not mapped to COCO-133.
+Ego-only (Aria device, no exo cameras). Uses preprocessed MP4 videos
+(from H.265 VRS), MPS SLAM trajectories for camera poses, and MPS hand
+tracking providing full 21-landmark 3D hand keypoints in device frame.
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Generator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import numpy as np
 import rerun as rr
-from jaxtyping import Int
+from jaxtyping import Float32, Int, Int64
 from natsort import natsorted
 from numpy import ndarray
 from rerun.components.view_coordinates import ViewCoordinates
@@ -24,6 +24,8 @@ from simplecv.data.ego.base_ego import BaseEgoSequence
 from simplecv.data.exo.base_exo import BaseExoSequence
 from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample
 from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
+from simplecv.data.hot3d_utils import lookup_nearest_poses, parse_mps_closed_loop_trajectory
+from simplecv.data.skeleton.assembly_hands import assembly21_to_coco133
 
 
 @dataclass
@@ -70,7 +72,7 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
         return None  # ego-only
 
     def load_stream_timestamps_ns(self) -> dict[str, Int[ndarray, "n_frames"]]:
-        """Return per-stream timestamps for ego videos."""
+        """Return per-stream timestamps for ego videos (and labels if available)."""
         stream_ts: dict[str, Int[ndarray, "n_frames"]] = {}
         self._ego_stream_names.clear()
 
@@ -85,14 +87,162 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
                 stream_ts[stream_name] = timestamps
                 self._ego_stream_names.append(stream_name)
 
+        labels: ExoEgoLabels | None = self.exoego_labels
+        if labels is not None and labels.timestamps_ns is not None:
+            stream_ts["labels"] = labels.timestamps_ns
+
         return stream_ts
 
     def load_labels(self) -> ExoEgoLabels | None:
-        """MPS hand tracking provides wrist+palm only, not COCO-133 keypoints.
+        """Load COCO-133 hand keypoints from MPS hand tracking results.
 
-        Return None since the data doesn't map to the expected 133-keypoint format.
+        MPS hand tracking provides 21 landmarks per hand in **device frame**
+        (meters), using the same ordering as Assembly-Hands / UmeTrack.
+        We transform them to world frame using the MPS SLAM trajectory and
+        then map to COCO-133 via ``assembly21_to_coco133``.
+
+        Timestamp alignment:
+        - MPS hand tracking timestamps are in device-time ``tracking_timestamp_us``
+          (same domain as the MPS SLAM trajectory).
+        - We filter to one label per video frame via nearest-neighbor matching
+          against the VRS device-time timestamps saved during preprocessing.
+        - Label timestamps are then normalized to the 0-based video timeline
+          (subtract VRS recording start time).
         """
-        return None
+        seq_dir: Path = self._sequence_dir()
+        hand_csv: Path = seq_dir / "mps" / "hand_tracking" / "hand_tracking_results.csv"
+        if not hand_csv.exists():
+            return None
+
+        import pandas as pd
+
+        df: pd.DataFrame = pd.read_csv(hand_csv)
+        if df.empty:
+            return None
+
+        # ── Timestamps: μs → ns (device-time domain) ─────────────────────
+        hand_ts_ns: Int64[ndarray, "n_hand"] = (df["tracking_timestamp_us"].values * np.int64(1000)).astype(np.int64)
+
+        # ── Load trajectory for device→world transform ────────────────────
+        traj_csv: Path = seq_dir / "mps" / "slam" / "closed_loop_trajectory.csv"
+        assert traj_csv.exists(), f"Trajectory not found at {traj_csv}"
+        traj_result: tuple[
+            Int64[ndarray, "n_poses"], Float32[ndarray, "n_poses 4 4"], Float32[ndarray, "n_poses"]
+        ] = parse_mps_closed_loop_trajectory(traj_csv)
+        traj_ts_ns: Int64[ndarray, "n_poses"] = traj_result[0]
+        world_T_device_all: Float32[ndarray, "n_poses 4 4"] = traj_result[1]
+
+        # Look up world_T_device for every hand tracking frame
+        world_T_device_hand: Float32[ndarray, "n_hand 4 4"] = lookup_nearest_poses(
+            query_ts_ns=hand_ts_ns,
+            trajectory_ts_ns=traj_ts_ns,
+            world_T_device=world_T_device_all,
+        )
+
+        # ── Extract 21 landmarks per hand (device frame, meters) ──────────
+        n_hand: int = len(df)
+        left_conf: Float32[ndarray, "n_hand"] = df["left_tracking_confidence"].values.astype(np.float32)
+        right_conf: Float32[ndarray, "n_hand"] = df["right_tracking_confidence"].values.astype(np.float32)
+
+        # Build (n_hand, 21, 3) arrays for left and right in device frame
+        left_device: Float32[ndarray, "n_hand 21 3"] = np.zeros((n_hand, 21, 3), dtype=np.float32)
+        right_device: Float32[ndarray, "n_hand 21 3"] = np.zeros((n_hand, 21, 3), dtype=np.float32)
+        for lm_idx in range(21):
+            for axis_idx, axis in enumerate(["x", "y", "z"]):
+                left_col: str = f"t{axis}_left_landmark_{lm_idx}_device"
+                right_col: str = f"t{axis}_right_landmark_{lm_idx}_device"
+                left_device[:, lm_idx, axis_idx] = df[left_col].values.astype(np.float32)
+                right_device[:, lm_idx, axis_idx] = df[right_col].values.astype(np.float32)
+
+        # ── Transform device→world ────────────────────────────────────────
+        # world_point = R @ device_point + t
+        R_all: Float32[ndarray, "n_hand 3 3"] = world_T_device_hand[:, :3, :3]
+        t_all: Float32[ndarray, "n_hand 3"] = world_T_device_hand[:, :3, 3]
+
+        # Vectorized: (n_hand, 21, 3) = einsum('nij,nkj->nki', R, pts) + t[:,None,:]
+        left_world: Float32[ndarray, "n_hand 21 3"] = np.einsum("nij,nkj->nki", R_all, left_device) + t_all[:, np.newaxis, :]
+        right_world: Float32[ndarray, "n_hand 21 3"] = np.einsum("nij,nkj->nki", R_all, right_device) + t_all[:, np.newaxis, :]
+
+        # Zero out invalid detections (confidence <= 0)
+        left_invalid: ndarray = left_conf <= 0
+        right_invalid: ndarray = right_conf <= 0
+        left_world[left_invalid] = np.nan
+        right_world[right_invalid] = np.nan
+
+        # ── Filter to video-frame-aligned entries ─────────────────────────
+        vrs_ts_path: Path = seq_dir / "_simplecv" / "timestamps_ns.json"
+        assert vrs_ts_path.exists(), f"VRS timestamps not found at {vrs_ts_path}"
+        vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())
+        first_stream: str = next(iter(vrs_ts_data))
+        vrs_ref_ts: Int64[ndarray, "n_video"] = np.array(vrs_ts_data[first_stream], dtype=np.int64)
+
+        # Nearest-neighbor: for each video frame, find closest hand tracking frame
+        insertion: Int64[ndarray, "n_video"] = np.searchsorted(hand_ts_ns, vrs_ref_ts, side="left").astype(np.int64)
+        left_idx: Int64[ndarray, "n_video"] = np.clip(insertion - 1, 0, n_hand - 1).astype(np.int64)
+        right_idx: Int64[ndarray, "n_video"] = np.clip(insertion, 0, n_hand - 1).astype(np.int64)
+        left_delta: Int64[ndarray, "n_video"] = np.abs(vrs_ref_ts - hand_ts_ns[left_idx])
+        right_delta: Int64[ndarray, "n_video"] = np.abs(hand_ts_ns[right_idx] - vrs_ref_ts)
+        aligned_idx: Int64[ndarray, "n_video"] = np.where(left_delta <= right_delta, left_idx, right_idx).astype(np.int64)
+
+        left_aligned: Float32[ndarray, "n_video 21 3"] = left_world[aligned_idx]
+        right_aligned: Float32[ndarray, "n_video 21 3"] = right_world[aligned_idx]
+        left_conf_aligned: Float32[ndarray, "n_video"] = left_conf[aligned_idx]
+        right_conf_aligned: Float32[ndarray, "n_video"] = right_conf[aligned_idx]
+        hand_ts_aligned: Int64[ndarray, "n_video"] = hand_ts_ns[aligned_idx]
+
+        # ── Map to COCO-133 ───────────────────────────────────────────────
+        num_frames: int = len(vrs_ref_ts)
+        xyzc_stack: Float32[ndarray, "num_frames 133 4"] = np.full((num_frames, 133, 4), np.nan, dtype=np.float32)
+        xyzc_stack[:, :, 3] = np.float32(0.0)
+
+        prev_landmarks_lr: Float32[ndarray, "2 21 3"] = np.full((2, 21, 3), np.nan, dtype=np.float32)
+
+        for frame_idx in range(num_frames):
+            landmarks_lr: Float32[ndarray, "2 21 3"] = np.full((2, 21, 3), np.nan, dtype=np.float32)
+
+            # Left hand
+            l_conf: float = float(left_conf_aligned[frame_idx])
+            if l_conf > 0:
+                landmarks_lr[0] = left_aligned[frame_idx]
+                prev_landmarks_lr[0] = left_aligned[frame_idx]
+            else:
+                landmarks_lr[0] = prev_landmarks_lr[0]
+
+            # Right hand
+            r_conf: float = float(right_conf_aligned[frame_idx])
+            if r_conf > 0:
+                landmarks_lr[1] = right_aligned[frame_idx]
+                prev_landmarks_lr[1] = right_aligned[frame_idx]
+            else:
+                landmarks_lr[1] = prev_landmarks_lr[1]
+
+            xyzc_stack[frame_idx] = assembly21_to_coco133(landmarks_lr)
+
+            # Set confidence for hand keypoints (matching HOT3D pattern)
+            adjustments: tuple[tuple[int, int], ...] = ((0, 91), (1, 112))
+            wrist_indices: tuple[int, int] = (9, 10)
+            thumb_base_indices: tuple[int, int] = (92, 113)
+            for hand_idx, coco_offset in adjustments:
+                conf: float = float(left_conf_aligned[frame_idx]) if hand_idx == 0 else float(right_conf_aligned[frame_idx])
+                conf = max(conf, 0.0)
+                if conf <= 0.0:
+                    xyzc_stack[frame_idx, coco_offset: coco_offset + 21, 3] = np.float32(0.0)
+                    xyzc_stack[frame_idx, wrist_indices[hand_idx], 3] = np.float32(0.0)
+                    xyzc_stack[frame_idx, thumb_base_indices[hand_idx], 3] = np.float32(0.0)
+                else:
+                    xyzc_stack[frame_idx, coco_offset: coco_offset + 21, 3] = np.float32(conf)
+                    xyzc_stack[frame_idx, wrist_indices[hand_idx], 3] = np.float32(conf)
+                    if not np.isnan(xyzc_stack[frame_idx, thumb_base_indices[hand_idx], :3]).all():
+                        xyzc_stack[frame_idx, thumb_base_indices[hand_idx], 3] = np.float32(conf)
+
+        # Normalize timestamps to 0-based video timeline
+        vrs_start_ns: np.int64 = np.int64(vrs_ref_ts[0])
+        normalized_ts: Int64[ndarray, "num_frames"] = hand_ts_aligned - vrs_start_ns
+
+        return ExoEgoLabels(
+            xyzc_stack=xyzc_stack,
+            timestamps_ns=normalized_ts,
+        )
 
     @classmethod
     def iter_episode_sequences(cls, cfg: AriaGen2PilotConfig) -> Generator["AriaGen2PilotSequence", None, None]:

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -35,7 +35,7 @@ class AriaGen2PilotConfig(BaseExoEgoDatasetConfig):
     _target: type = field(default_factory=lambda: AriaGen2PilotSequence)
     base_directory: Path = Path("/mnt/8tb/data/aria-gen2-pilot")
     """Base directory containing sequence subdirectories."""
-    sequence_name: str = "walk_1"
+    sequence_name: str = "cook_0"
     """Sequence folder name (e.g. 'walk_1', 'cook_0', 'eat_0')."""
 
 

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -170,6 +170,11 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
         right_world[right_invalid] = np.nan
 
         # ── Filter to video-frame-aligned entries ─────────────────────────
+        # Hand tracking runs at 30fps but we downsample to the RGB 10fps
+        # timeline (one label per RGB frame) because the viewer shares a
+        # single frame count across all ego cameras and labels.
+        # TODO: emit labels at native 30fps once the viewer supports
+        # per-stream frame rates.
         vrs_ts_path: Path = seq_dir / "_simplecv" / "timestamps_ns.json"
         assert vrs_ts_path.exists(), f"VRS timestamps not found at {vrs_ts_path}"
         vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -8,6 +8,7 @@ tracking providing full 21-landmark 3D hand keypoints in device frame.
 from __future__ import annotations
 
 import json
+import warnings
 from collections.abc import Generator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -201,26 +202,25 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
         xyzc_stack: Float32[ndarray, "num_frames 133 4"] = np.full((num_frames, 133, 4), np.nan, dtype=np.float32)
         xyzc_stack[:, :, 3] = np.float32(0.0)
 
-        prev_landmarks_lr: Float32[ndarray, "2 21 3"] = np.full((2, 21, 3), np.nan, dtype=np.float32)
+        n_gaps_left: int = 0
+        n_gaps_right: int = 0
 
         for frame_idx in range(num_frames):
             landmarks_lr: Float32[ndarray, "2 21 3"] = np.full((2, 21, 3), np.nan, dtype=np.float32)
 
-            # Left hand
+            # Left hand — NaN if not detected (confidence <= 0)
             l_conf: float = float(left_conf_aligned[frame_idx])
             if l_conf > 0:
                 landmarks_lr[0] = left_aligned[frame_idx]
-                prev_landmarks_lr[0] = left_aligned[frame_idx]
             else:
-                landmarks_lr[0] = prev_landmarks_lr[0]
+                n_gaps_left += 1
 
-            # Right hand
+            # Right hand — NaN if not detected (confidence <= 0)
             r_conf: float = float(right_conf_aligned[frame_idx])
             if r_conf > 0:
                 landmarks_lr[1] = right_aligned[frame_idx]
-                prev_landmarks_lr[1] = right_aligned[frame_idx]
             else:
-                landmarks_lr[1] = prev_landmarks_lr[1]
+                n_gaps_right += 1
 
             xyzc_stack[frame_idx] = assembly21_to_coco133(landmarks_lr)
 
@@ -240,6 +240,19 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
                     xyzc_stack[frame_idx, wrist_indices[hand_idx], 3] = np.float32(conf)
                     if not np.isnan(xyzc_stack[frame_idx, thumb_base_indices[hand_idx], :3]).all():
                         xyzc_stack[frame_idx, thumb_base_indices[hand_idx], 3] = np.float32(conf)
+
+        if n_gaps_left > 0:
+            warnings.warn(
+                f"Left hand not detected in {n_gaps_left}/{num_frames} frames "
+                f"({n_gaps_left / num_frames * 100:.0f}%). Those frames have NaN keypoints.",
+                stacklevel=2,
+            )
+        if n_gaps_right > 0:
+            warnings.warn(
+                f"Right hand not detected in {n_gaps_right}/{num_frames} frames "
+                f"({n_gaps_right / num_frames * 100:.0f}%). Those frames have NaN keypoints.",
+                stacklevel=2,
+            )
 
         # Normalize timestamps to 0-based video timeline
         vrs_start_ns: np.int64 = np.int64(vrs_ref_ts[0])

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -170,9 +170,10 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
         right_world[right_invalid] = np.nan
 
         # ── Filter to video-frame-aligned entries ─────────────────────────
-        # Hand tracking runs at 30fps but we downsample to the RGB 10fps
-        # timeline (one label per RGB frame) because the viewer shares a
-        # single frame count across all ego cameras and labels.
+        # Hand tracking and SLAM cameras both run at 30fps, but we
+        # downsample to the RGB 10fps timeline (one label per RGB frame)
+        # because the viewer shares a single frame count across all ego
+        # cameras and labels.
         # TODO: emit labels at native 30fps once the viewer supports
         # per-stream frame rates.
         vrs_ts_path: Path = seq_dir / "_simplecv" / "timestamps_ns.json"

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -180,8 +180,14 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
         vrs_ts_path: Path = seq_dir / "_simplecv" / "timestamps_ns.json"
         assert vrs_ts_path.exists(), f"VRS timestamps not found at {vrs_ts_path}"
         vrs_ts_data: dict = json.loads(vrs_ts_path.read_text())
-        first_stream: str = next(iter(vrs_ts_data))
-        vrs_ref_ts: Int64[ndarray, "n_video"] = np.array(vrs_ts_data[first_stream], dtype=np.int64)
+        rgb_stream_name: str = "camera-rgb"
+        if rgb_stream_name not in vrs_ts_data:
+            available_streams: list[str] = list(vrs_ts_data.keys())
+            raise KeyError(
+                f"RGB timestamps missing from {vrs_ts_path}: expected key "
+                f"{rgb_stream_name!r}, found {available_streams!r}"
+            )
+        vrs_ref_ts: Int64[ndarray, "n_video"] = np.array(vrs_ts_data[rgb_stream_name], dtype=np.int64)
 
         # Nearest-neighbor: for each video frame, find closest hand tracking frame
         insertion: Int64[ndarray, "n_video"] = np.searchsorted(hand_ts_ns, vrs_ref_ts, side="left").astype(np.int64)
@@ -195,7 +201,6 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
         right_aligned: Float32[ndarray, "n_video 21 3"] = right_world[aligned_idx]
         left_conf_aligned: Float32[ndarray, "n_video"] = left_conf[aligned_idx]
         right_conf_aligned: Float32[ndarray, "n_video"] = right_conf[aligned_idx]
-        hand_ts_aligned: Int64[ndarray, "n_video"] = hand_ts_ns[aligned_idx]
 
         # ── Map to COCO-133 ───────────────────────────────────────────────
         num_frames: int = len(vrs_ref_ts)
@@ -254,9 +259,10 @@ class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
                 stacklevel=2,
             )
 
-        # Normalize timestamps to 0-based video timeline
-        vrs_start_ns: np.int64 = np.int64(vrs_ref_ts[0])
-        normalized_ts: Int64[ndarray, "num_frames"] = hand_ts_aligned - vrs_start_ns
+        # Labels are aligned one-per-video-frame, so their normalized
+        # timestamps follow the video timeline exactly rather than the
+        # nearest hand sample timestamps (which may have small jitter).
+        normalized_ts: Int64[ndarray, "num_frames"] = (vrs_ref_ts - vrs_ref_ts[0]).astype(np.int64)
 
         return ExoEgoLabels(
             xyzc_stack=xyzc_stack,

--- a/simplecv/data/exoego/aria_gen2_pilot.py
+++ b/simplecv/data/exoego/aria_gen2_pilot.py
@@ -1,0 +1,128 @@
+"""Aria Gen2 Pilot dataset adapter for the ExoEgo visualization pipeline.
+
+Ego-only (Aria device, no exo cameras). Uses preprocessed AV1 MP4 videos
+(from VRS), MPS SLAM trajectories for camera poses. MPS hand tracking
+provides wrist+palm positions only (not full finger keypoints), so labels
+are not mapped to COCO-133.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+import numpy as np
+import rerun as rr
+from jaxtyping import Int
+from natsort import natsorted
+from numpy import ndarray
+from rerun.components.view_coordinates import ViewCoordinates
+
+from simplecv.data.ego.aria_gen2_pilot_ego import AriaGen2PilotEgoSequence
+from simplecv.data.ego.base_ego import BaseEgoSequence
+from simplecv.data.exo.base_exo import BaseExoSequence
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample
+from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
+
+
+@dataclass
+class AriaGen2PilotConfig(BaseExoEgoDatasetConfig):
+    """Configuration for Aria Gen2 Pilot sequences."""
+
+    _target: type = field(default_factory=lambda: AriaGen2PilotSequence)
+    base_directory: Path = Path("/mnt/8tb/data/aria-gen2-pilot")
+    """Base directory containing sequence subdirectories."""
+    sequence_name: str = "walk_1"
+    """Sequence folder name (e.g. 'walk_1', 'cook_0', 'eat_0')."""
+
+
+class AriaGen2PilotSequence(BaseExoEgoSequence[AriaGen2PilotConfig]):
+    """Aria Gen2 Pilot dataset adapter (ego-only, Aria device)."""
+
+    def __init__(self, cfg: AriaGen2PilotConfig) -> None:
+        self._ego_stream_names: list[str] = []
+        self._exo_stream_names: list[str] = []
+        super().__init__(cfg)
+
+    def _sequence_dir(self) -> Path:
+        return Path(self.config.base_directory) / self.config.sequence_name
+
+    def __getitem__(self, idx: int | None = None, ts_nano: np.timedelta64 | None = None) -> ExoEgoSample:
+        canonical_idx, ts_ns = self._resolve_canonical(idx=idx, ts_nano=ts_nano)
+        ego_cam_params_list, ego_bgr_list = self._sample_ego(ts_ns)
+        labels: ExoEgoLabels | None = self._sample_labels(canonical_idx, ts_ns)
+
+        return ExoEgoSample(
+            canonical_index=canonical_idx,
+            canonical_timestamp_ns=ts_ns,
+            ego_cam_params_list=ego_cam_params_list,
+            ego_bgr_list=ego_bgr_list,
+            exo_cam_params_list=None,
+            exo_bgr_list=None,
+            labels=labels,
+        )
+
+    def _build_ego(self) -> BaseEgoSequence[AriaGen2PilotConfig] | None:
+        return AriaGen2PilotEgoSequence(cfg=self.config)
+
+    def _build_exo(self) -> BaseExoSequence[AriaGen2PilotConfig] | None:
+        return None  # ego-only
+
+    def load_stream_timestamps_ns(self) -> dict[str, Int[ndarray, "n_frames"]]:
+        """Return per-stream timestamps for ego videos."""
+        stream_ts: dict[str, Int[ndarray, "n_frames"]] = {}
+        self._ego_stream_names.clear()
+
+        if self.ego_sequence is not None:
+            for name, video_path in zip(
+                self.ego_sequence.ego_video_names,
+                self.ego_sequence.ego_video_paths,
+                strict=True,
+            ):
+                stream_name: str = f"ego/{name}"
+                timestamps: Int[ndarray, "n_frames"] = rr.AssetVideo(path=video_path).read_frame_timestamps_nanos()
+                stream_ts[stream_name] = timestamps
+                self._ego_stream_names.append(stream_name)
+
+        return stream_ts
+
+    def load_labels(self) -> ExoEgoLabels | None:
+        """MPS hand tracking provides wrist+palm only, not COCO-133 keypoints.
+
+        Return None since the data doesn't map to the expected 133-keypoint format.
+        """
+        return None
+
+    @classmethod
+    def iter_episode_sequences(cls, cfg: AriaGen2PilotConfig) -> Generator["AriaGen2PilotSequence", None, None]:
+        """Iterate over all sequences in the dataset directory.
+
+        Yields one ``AriaGen2PilotSequence`` per folder with preprocessed MP4s.
+        """
+        root: Path = cfg.base_directory
+        assert root.exists(), f"Aria Gen2 Pilot root directory {root} does not exist."
+
+        def _has_preprocessed_streams(d: Path) -> bool:
+            simplecv_dir: Path = d / "_simplecv"
+            return simplecv_dir.is_dir() and any(simplecv_dir.glob("*.mp4"))
+
+        seq_dirs: list[Path] = natsorted([
+            d for d in root.iterdir()
+            if d.is_dir() and _has_preprocessed_streams(d)
+        ])
+
+        for seq_dir in seq_dirs:
+            episode_cfg: AriaGen2PilotConfig = replace(
+                cfg,
+                sequence_name=seq_dir.name,
+            )
+            try:
+                yield cls(episode_cfg)
+            except Exception as exc:  # pragma: no cover
+                print(f"[skip] {seq_dir.name}: {exc}")
+
+    @property
+    def world_coordinate_system(self) -> ViewCoordinates:
+        """Aria: gravity = [0,0,-9.81] → +Z is up."""
+        return rr.ViewCoordinates.RIGHT_HAND_Z_UP

--- a/simplecv/data/hot3d_utils.py
+++ b/simplecv/data/hot3d_utils.py
@@ -23,8 +23,8 @@ from serde.json import from_json, to_json
 
 
 @serde
-class Hot3dStreamCalibration:
-    """Calibration for a single HOT3D camera stream (Aria or Quest 3).
+class AriaStreamCalibration:
+    """Calibration for a single Meta camera stream (Aria or Quest 3).
 
     Both headsets use Meta's FISHEYE624 (FisheyeRadTanThinPrism) projection
     model, but with different parameter layouts:
@@ -62,22 +62,30 @@ class Hot3dStreamCalibration:
     """4x4 transform from camera frame to device (CPF) frame, row-major."""
 
 
+# Backward-compatible aliases
+Hot3dStreamCalibration = AriaStreamCalibration
+
+
 @serde
-class Hot3dSequenceCalibration:
-    """All camera calibrations for a HOT3D sequence."""
+class AriaSequenceCalibration:
+    """All camera calibrations for a sequence (Aria or Quest 3)."""
 
-    streams: list[Hot3dStreamCalibration]
+    streams: list[AriaStreamCalibration]
 
 
-def save_calibration(cal: Hot3dSequenceCalibration, path: Path) -> None:
+# Backward-compatible alias
+Hot3dSequenceCalibration = AriaSequenceCalibration
+
+
+def save_calibration(cal: AriaSequenceCalibration, path: Path) -> None:
     """Serialize calibration to JSON."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(to_json(cal))
 
 
-def load_calibration(path: Path) -> Hot3dSequenceCalibration:
+def load_calibration(path: Path) -> AriaSequenceCalibration:
     """Deserialize calibration from JSON."""
-    return from_json(Hot3dSequenceCalibration, path.read_text())
+    return from_json(AriaSequenceCalibration, path.read_text())
 
 
 # ──────────────────── Headset detection ────────────────────────────────── #
@@ -214,7 +222,7 @@ QUEST_STREAM_ID_TO_LABEL: dict[str, str] = {
 }
 
 
-def parse_online_calibration_first(jsonl_path: Path) -> Hot3dSequenceCalibration:
+def parse_online_calibration_first(jsonl_path: Path) -> AriaSequenceCalibration:
     """Parse the first entry of online_calibration.jsonl to get factory calibration.
 
     The online calibration updates per-frame, but the intrinsics change very
@@ -228,7 +236,7 @@ def parse_online_calibration_first(jsonl_path: Path) -> Hot3dSequenceCalibration
     with open(jsonl_path) as f:
         first_entry: dict = json.loads(f.readline())
 
-    streams: list[Hot3dStreamCalibration] = []
+    streams: list[AriaStreamCalibration] = []
     for cam in first_entry["CameraCalibrations"]:
         label: str = cam["Label"]
         params: list[float] = cam["Projection"]["Params"]
@@ -255,7 +263,7 @@ def parse_online_calibration_first(jsonl_path: Path) -> Hot3dSequenceCalibration
         t_translation: list[float] = t_dev_cam["Translation"]
         device_T_camera: Float32[ndarray, "4 4"] = build_4x4(R_dev_cam, t_translation)
 
-        stream_cal: Hot3dStreamCalibration = Hot3dStreamCalibration(
+        stream_cal: AriaStreamCalibration = AriaStreamCalibration(
             stream_label=label,
             width=width,
             height=height,
@@ -275,13 +283,13 @@ def parse_online_calibration_first(jsonl_path: Path) -> Hot3dSequenceCalibration
         )
         streams.append(stream_cal)
 
-    return Hot3dSequenceCalibration(streams=streams)
+    return AriaSequenceCalibration(streams=streams)
 
 
 # ─────────── camera_models.json parser (Aria + Quest) ─────────────────────── #
 
 
-def parse_camera_models_json(json_path: Path) -> Hot3dSequenceCalibration:
+def parse_camera_models_json(json_path: Path) -> AriaSequenceCalibration:
     """Parse ``camera_models.json`` — works for both Aria and Quest 3.
 
     Aria has 15 projection params: ``[f, cx, cy, k1-k6, p1-p2, s1-s4]``
@@ -294,7 +302,7 @@ def parse_camera_models_json(json_path: Path) -> Hot3dSequenceCalibration:
     with open(json_path) as f:
         cameras: list[dict] = json.load(f)
 
-    streams: list[Hot3dStreamCalibration] = []
+    streams: list[AriaStreamCalibration] = []
     for cam in cameras:
         label: str = cam["label"]
         params: list[float] = cam["projectionParams"]
@@ -330,7 +338,7 @@ def parse_camera_models_json(json_path: Path) -> Hot3dSequenceCalibration:
         # model. Thin-prism terms s1-s4 are dropped — validated to produce <1px
         # error against the full OVR624Distortion model on HOT3D data.
         d: int = distortion_offset
-        stream_cal: Hot3dStreamCalibration = Hot3dStreamCalibration(
+        stream_cal: AriaStreamCalibration = AriaStreamCalibration(
             stream_label=label,
             width=width,
             height=height,
@@ -350,7 +358,7 @@ def parse_camera_models_json(json_path: Path) -> Hot3dSequenceCalibration:
         )
         streams.append(stream_cal)
 
-    return Hot3dSequenceCalibration(streams=streams)
+    return AriaSequenceCalibration(streams=streams)
 
 
 # ─────────── headset_trajectory.csv parser (Aria + Quest) ─────────────────── #

--- a/simplecv/video_encoder.py
+++ b/simplecv/video_encoder.py
@@ -55,6 +55,79 @@ def _encoder_options(name: str) -> dict[str, str]:
     return {}
 
 
+# ─────────────── ffmpeg subprocess transcode ──────────────────────────────── #
+# Used when the source codec (e.g. monochrome H.265 Rext) cannot be handled
+# by PyAV's NVENC path or needs pixel format conversion. ~10x faster than
+# the equivalent PyAV decode→reformat→encode loop because ffmpeg runs the
+# full pipeline in C without Python frame iteration overhead.
+
+
+def pick_ffmpeg_encoder() -> str:
+    """Return the best available ffmpeg AV1/H.265 encoder.
+
+    Prefers NVENC GPU (``av1_nvenc`` > ``hevc_nvenc``) then CPU fallback
+    (``libsvtav1``).
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-encoders"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    encoders: str = result.stdout
+
+    for candidate in ["av1_nvenc", "hevc_nvenc"]:
+        if candidate in encoders:
+            return candidate
+    return "libsvtav1"
+
+
+def ffmpeg_transcode(
+    input_path: Path,
+    output_path: Path,
+    input_format: str = "hevc",
+    fps: int = 30,
+    encoder: str | None = None,
+) -> None:
+    """Transcode a raw video bitstream to yuv420p MP4 via ffmpeg subprocess.
+
+    Uses NVENC GPU encoding by default. Settings match :class:`MP4Writer`:
+    GOP=30, no B-frames, NVENC default quality or CRF 30 for CPU fallback.
+
+    Args:
+        input_path: Raw bitstream file (e.g. Annex-B ``.h265``).
+        output_path: Destination ``.mp4`` path.
+        input_format: ffmpeg input format (``hevc``, ``h264``, etc.).
+        fps: Output frame rate.
+        encoder: Explicit encoder name, or ``None`` to auto-detect via
+            :func:`pick_ffmpeg_encoder`.
+    """
+    import subprocess
+
+    if encoder is None:
+        encoder = pick_ffmpeg_encoder()
+
+    encoder_args: list[str] = [
+        "-c:v", encoder, "-pix_fmt", "yuv420p",
+        "-g", str(_GOP_SIZE), "-bf", "0",
+    ]
+    if encoder == "libsvtav1":
+        encoder_args += ["-crf", str(_CRF), "-preset", "8"]
+
+    cmd: list[str] = [
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+        "-f", input_format, "-i", str(input_path),
+        *encoder_args,
+        "-r", str(fps),
+        str(output_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    if result.returncode:
+        raise RuntimeError(f"ffmpeg transcode failed: {result.stderr[-300:]}")
+
+
 # ──────────────────── VideoEncoder (raw packets) ──────────────────────────── #
 
 

--- a/simplecv/video_encoder.py
+++ b/simplecv/video_encoder.py
@@ -67,8 +67,14 @@ def pick_ffmpeg_encoder() -> str:
 
     Prefers NVENC GPU (``av1_nvenc`` > ``hevc_nvenc``) then CPU fallback
     (``libsvtav1``).
+
+    Raises ``RuntimeError`` if ffmpeg is not installed.
     """
+    import shutil
     import subprocess
+
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError("ffmpeg not found on PATH. Install ffmpeg to preprocess Aria Gen2 VRS files.")
 
     result = subprocess.run(
         ["ffmpeg", "-hide_banner", "-encoders"],
@@ -76,6 +82,9 @@ def pick_ffmpeg_encoder() -> str:
         text=True,
         timeout=10,
     )
+    if result.returncode:
+        raise RuntimeError(f"ffmpeg -encoders failed: {result.stderr[:200]}")
+
     encoders: str = result.stdout
 
     for candidate in ["av1_nvenc", "hevc_nvenc"]:
@@ -125,9 +134,11 @@ def ffmpeg_transcode(
 
     cmd: list[str] = [
         "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+        # -r before -i sets the input framerate so ffmpeg doesn't assume
+        # a default (25fps) and resample/duplicate frames.
+        "-r", str(fps),
         "-f", input_format, "-i", str(input_path),
         *encoder_args,
-        "-r", str(fps),
         str(output_path),
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)

--- a/simplecv/video_encoder.py
+++ b/simplecv/video_encoder.py
@@ -90,11 +90,12 @@ def ffmpeg_transcode(
     input_format: str = "hevc",
     fps: int = 30,
     encoder: str | None = None,
+    cq: int | None = None,
 ) -> None:
     """Transcode a raw video bitstream to yuv420p MP4 via ffmpeg subprocess.
 
-    Uses NVENC GPU encoding by default. Settings match :class:`MP4Writer`:
-    GOP=30, no B-frames, NVENC default quality or CRF 30 for CPU fallback.
+    Uses NVENC GPU encoding by default with constant-quality (CQ) mode.
+    GOP=30, no B-frames.
 
     Args:
         input_path: Raw bitstream file (e.g. Annex-B ``.h265``).
@@ -103,6 +104,9 @@ def ffmpeg_transcode(
         fps: Output frame rate.
         encoder: Explicit encoder name, or ``None`` to auto-detect via
             :func:`pick_ffmpeg_encoder`.
+        cq: NVENC constant-quality value (0–51, higher = smaller file).
+            ``None`` uses the NVENC default (~28). For CPU fallback the
+            module-level ``_CRF`` is used instead.
     """
     import subprocess
 
@@ -113,7 +117,10 @@ def ffmpeg_transcode(
         "-c:v", encoder, "-pix_fmt", "yuv420p",
         "-g", str(_GOP_SIZE), "-bf", "0",
     ]
-    if encoder == "libsvtav1":
+    if "nvenc" in encoder:
+        if cq is not None:
+            encoder_args += ["-cq", str(cq)]
+    elif encoder == "libsvtav1":
         encoder_args += ["-crf", str(_CRF), "-preset", "8"]
 
     cmd: list[str] = [

--- a/tools/download_aria_gen2_pilot.py
+++ b/tools/download_aria_gen2_pilot.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.download_aria_gen2_pilot import DownloadConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(DownloadConfig, description="Download Aria Gen2 Pilot sequences from CDN URL JSON."))

--- a/tools/preprocess_aria_gen2_pilot.py
+++ b/tools/preprocess_aria_gen2_pilot.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.preprocess_aria_gen2_pilot import PreprocessConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PreprocessConfig, description="Preprocess Aria Gen2 Pilot VRS files to AV1 MP4."))


### PR DESCRIPTION
## Summary

Adds full integration of the **Aria Gen2 Pilot** dataset into the ExoEgo visualization pipeline, following the pattern established by HOT3D. This is an Aria-only ego dataset with 5 cameras (RGB + 4 SLAM) and MPS-based 3D hand tracking.

**Usage:**
```bash
pixi run download-aria-gen2-pilot
pixi run preprocess-aria-gen2-pilot
pixi run view-exoego-data aria-gen2  # defaults to cook_0
```

## What changed

### New files
- **`apis/download_utils.py`** — shared download utilities (`download_file`, `extract_zip`, `verify_sha1`) extracted from HOT3D for reuse
- **`apis/download_aria_gen2_pilot.py`** — reads `AriaGen2PilotDataset_download_urls.json` with pyserde-typed schema (`AriaGen2PilotUrlJson` → `SequenceUrls` → `DataTypeEntry`)
- **`apis/preprocess_aria_gen2_pilot.py`** — VRS → AV1 MP4 preprocessing via `ffmpeg` subprocess + NVENC GPU encode (~20s per sequence for all 5 streams)
- **`data/ego/aria_gen2_pilot_ego.py`** — 5-camera ego sequence (2560×1920 RGB + 4× 512×512 SLAM) with per-frame fisheye camera params sampled at RGB rate
- **`data/exoego/aria_gen2_pilot.py`** — config + sequence registered as `aria-gen2` CLI subcommand. Loads MPS hand tracking (21 landmarks per hand → device→world transform → COCO-133)
- **`tools/download_aria_gen2_pilot.py`**, **`tools/preprocess_aria_gen2_pilot.py`** — CLI wrappers

### Modified files
- **`video_encoder.py`** — added `pick_ffmpeg_encoder()` and `ffmpeg_transcode()` as reusable utilities for ffmpeg subprocess encoding with NVENC/CPU fallback
- **`data/hot3d_utils.py`** — renamed `Hot3dStreamCalibration` → `AriaStreamCalibration`, `Hot3dSequenceCalibration` → `AriaSequenceCalibration` (backward-compatible aliases preserved)
- **`apis/download_hot3d.py`** — imports from shared `download_utils.py`, re-exports for backward compat
- **`configs/exoego_dataset_configs.py`** — registers `"aria-gen2": AriaGen2PilotConfig()`
- **`pyproject.toml`** — adds download + preprocess pixi tasks

## Key differences from HOT3D

| Aspect | HOT3D (Gen1) | Aria Gen2 Pilot |
|--------|-------------|-----------------|
| VRS encoding | JPEG per frame | H.265 video codec (monochrome Rext) |
| Cameras | 3 (RGB + 2 SLAM) | 5 (RGB + 4 SLAM) |
| SLAM resolution | 640×480 | 512×512 |
| RGB resolution | 1408×1408 | 2560×1920 |
| Frame rates | All ~30fps | RGB 10fps, SLAM 30fps, hand tracking 30fps, trajectory 1kHz |
| Hand annotations | UmeTrack JSONL (joint angles + FK) | MPS CSV (21 landmarks in device frame) |
| VRS filename | `recording.vrs` | `video.vrs` |
| Preprocessing | PyAV JPEG decode → AV1 NVENC | ffmpeg subprocess: CPU H.265 decode → AV1 NVENC |

## Implementation details

- **H.265 monochrome handling**: VRS stores gray8 H.265 (Rext profile) which neither Rerun nor NVDEC can decode. Preprocessing uses `ffmpeg` subprocess with CPU H.265 decode (~380fps for 512×512) + AV1 NVENC encode. This is ~10x faster than the equivalent PyAV decode→reformat→encode loop because ffmpeg runs the full pipeline in C
- **Per-resolution quality tuning**: SLAM streams (512×512 grayscale, low entropy) use NVENC CQ 40 → ~17MB each. RGB uses NVENC default → ~85MB. Total ~149MB per sequence vs ~420MB without tuning
- **Mixed frame rate handling**: RGB runs at 10fps while SLAM cameras run at 30fps. All camera params are built at RGB timestamps so the viewer's shared-timeline assumption holds. TODO for future: per-stream native frame rates
- **Hand tracking**: MPS landmarks use Assembly-Hands ordering natively. Device→world transform is vectorized via `np.einsum`. Undetected frames emit NaN + summary warning instead of gap-filling with stale data
- **Reuses HOT3D utilities**: Calibration parsing, trajectory parsing, and nearest-neighbor pose lookup are shared since Gen2 uses the same Aria MPS format. Calibration classes renamed to `Aria*` with backward-compatible aliases

## Native data rates

| Stream | Rate |
|--------|------|
| RGB camera | 10 fps |
| SLAM cameras (×4) | 30 fps |
| MPS hand tracking | 30 fps |
| SLAM trajectory | 1,000 fps |

Currently everything is downsampled to 10fps (RGB timeline). SLAM videos play at native 30fps but poses/labels are at 10fps.

## Dataset size

- **Download**: 35.3 GB (12 sequences, VRS + MPS data)
- **Preprocessed**: ~1.8 GB (AV1 MP4s + calibration + timestamps)
- **Per sequence**: ~149 MB preprocessed

This PR was written using [Vibe Kanban](https://vibekanban.com)