### PR TITLE
Address ExoEgo catalog review follow-ups

### DIFF
--- a/simplecv/apis/exoego_forge_catalog.py
+++ b/simplecv/apis/exoego_forge_catalog.py
@@ -137,13 +137,7 @@ def build_exoego_catalog_blueprint(dataset_name: str) -> rrb.Blueprint:
         exo_video_log_paths=exo_video_log_paths,
         skip_camera_names=frozenset(),
     )
-    return rrb.Blueprint(
-        rrb.Horizontal(
-            contents=[container],
-            column_shares=[4, 1],
-        ),
-        collapse_panels=True,
-    )
+    return rrb.Blueprint(container, collapse_panels=True)
 
 
 def _register_default_dataset_blueprint(

--- a/simplecv/data/exoego/base_exoego.py
+++ b/simplecv/data/exoego/base_exoego.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Generic, Self, TypeVar
+from typing import Generic, TypeVar
 
 import cv2
 import numpy as np
 from jaxtyping import Float, Float32, Int, UInt8, UInt16
 from numpy import ndarray
 from rerun.components.view_coordinates import ViewCoordinates
+from typing_extensions import Self
 
 from simplecv.camera_parameters import Fisheye62Parameters, PinholeParameters
 from simplecv.data.ego.base_ego import BaseEgoSequence
@@ -338,7 +339,7 @@ class BaseExoEgoSequence(Generic[ConfigT], ABC):  # noqa: UP046
         if not end_times:
             raise ValueError("All provided stream timestamp arrays are empty.")
 
-        canonical_stream: str = min(end_times, key=end_times.get)
+        canonical_stream: str = min(end_times, key=lambda stream_name: end_times[stream_name])
         canonical_end_ns: int = end_times[canonical_stream]
         canonical_ts: Int[ndarray, "n_events"] = stream_ts[canonical_stream]
         # clip to its own end in case of trailing padding

--- a/simplecv/data/exoego/sequence_identity.py
+++ b/simplecv/data/exoego/sequence_identity.py
@@ -9,6 +9,8 @@ def _normalize_part(value: object) -> tuple[str, ...]:
     parts: tuple[str, ...] = tuple(part for part in raw.split("/") if part)
     if any(part in {".", ".."} for part in parts):
         raise ValueError(f"Invalid sequence identity part: {value!r}")
+    if any("__" in part for part in parts):
+        raise ValueError(f"Sequence identity parts cannot contain '__': {value!r}")
     return parts
 
 

--- a/tests/test_exoego_catalog.py
+++ b/tests/test_exoego_catalog.py
@@ -55,6 +55,22 @@ def test_sequence_identity_paths_and_recording_id() -> None:
 
 
 @pytest.mark.parametrize(
+    ("dataset", "parts"),
+    [
+        ("bad__dataset", ("sequence",)),
+        ("hocap", ("subject__1", "recording")),
+        ("hocap", ("subject_1/bad__recording",)),
+    ],
+)
+def test_sequence_identity_rejects_recording_id_separator(
+    dataset: str,
+    parts: tuple[str, ...],
+) -> None:
+    with pytest.raises(ValueError, match="cannot contain '__'"):
+        SequenceIdentity(dataset=dataset, parts=parts)
+
+
+@pytest.mark.parametrize(
     ("identity", "dataset", "sequence_key", "recording_id"),
     [
         (
@@ -461,4 +477,13 @@ def test_table_card_blueprints_play_uniform_selection_without_3d_range_override(
 def test_catalog_blueprints_exist_for_default_datasets() -> None:
     for dataset_name in DEFAULT_CATALOG_DATASETS:
         blueprint = build_exoego_catalog_blueprint(dataset_name)
+        root_container = blueprint.root_container
+        root_contents: list[Any] = list(root_container.contents)
+        column_shares: list[float] | None = getattr(root_container, "column_shares", None)
+        row_shares: list[float] | None = getattr(root_container, "row_shares", None)
+
         assert blueprint is not None
+        if column_shares is not None:
+            assert len(column_shares) == len(root_contents)
+        if row_shares is not None:
+            assert len(row_shares) == len(root_contents)

--- a/tools/exoego_tools/patch_rrd_metadata.py
+++ b/tools/exoego_tools/patch_rrd_metadata.py
@@ -13,6 +13,7 @@ import shutil
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import rerun as rr
 import rerun.experimental as rre
@@ -97,8 +98,12 @@ def patch_rrd_metadata(rrd_path: Path, metadata: RecordingMetadata) -> bool:
     """
     try:
         # Load original recording to get app_id and recording_id
-        reader: rre.RrdReader = rre.RrdReader(rrd_path)
-        store_entry: rre.StoreEntry = reader.recordings()[0]
+        reader: Any = rre.RrdReader(rrd_path)
+        recordings: list[Any] = list(reader.recordings())
+        if not recordings:
+            raise ValueError(f"No recordings found in {rrd_path}")
+
+        store_entry: Any = recordings[0]
         app_id: str = store_entry.application_id
         rec_id: str = store_entry.recording_id
 


### PR DESCRIPTION
## Summary
- Fix Python 3.10 Self import compatibility
- Remove invalid single-child catalog blueprint wrapper
- Guard metadata patching against empty RRD recordings
- Reject '__' in sequence identity parts to avoid recording id collisions

## Validation
- pixi run ruff check simplecv/data/exoego/base_exoego.py simplecv/apis/exoego_forge_catalog.py tools/exoego_tools/patch_rrd_metadata.py simplecv/data/exoego/sequence_identity.py tests/test_exoego_catalog.py
- pixi run tests tests/test_exoego_catalog.py
- pixi run -e dev pyrefly check simplecv/data/exoego/base_exoego.py simplecv/apis/exoego_forge_catalog.py tools/exoego_tools/patch_rrd_metadata.py simplecv/data/exoego/sequence_identity.py