### PR TITLE
[codex] Handle Hot3D labels and catalog mounting

### DIFF
--- a/simplecv/apis/exoego_forge_catalog.py
+++ b/simplecv/apis/exoego_forge_catalog.py
@@ -20,7 +20,6 @@ import pyarrow as pa
 import rerun as rr
 import rerun.blueprint as rrb
 from rerun import bindings
-from rerun.catalog import OnDuplicateSegmentLayer
 from rerun.recording_stream import RecordingStream
 from tqdm import tqdm
 
@@ -343,10 +342,8 @@ def mount_catalog(
         flush=True,
     )
 
-    server: rr.server.Server = rr.server.Server(datasets={name: [] for name in dataset_names}, port=port)
-    client = server.client()
-
-    iterator = tqdm(dataset_names, desc="register", unit="dataset", disable=not show_progress)
+    registration_paths_by_dataset: dict[str, list[Path]] = {}
+    iterator = tqdm(dataset_names, desc="prepare", unit="dataset", disable=not show_progress)
     for dataset_name in iterator:
         source_paths: list[Path] = paths_by_dataset[dataset_name]
         if optimize_for_catalog and dataset_name in optimize_datasets:
@@ -357,14 +354,15 @@ def mount_catalog(
             ]
         else:
             registration_paths = source_paths
+        registration_paths_by_dataset[dataset_name] = registration_paths
 
-        uris: list[str] = [path.as_uri() for path in registration_paths]
-        iterator.set_postfix_str(f"{dataset_name} register ({len(uris)} files)")
+    # Loading datasets at server startup avoids cumulative catalog RPC pressure
+    # for large datasets such as Assembly101 while preserving segment URLs.
+    server: rr.server.Server = rr.server.Server(datasets=registration_paths_by_dataset, port=port)
+    client = server.client()
+
+    for dataset_name in tqdm(dataset_names, desc="blueprint", unit="dataset", disable=not show_progress):
         dataset = client.get_dataset(dataset_name)
-        # Keep registration batched for importer throughput. REPLACE is intentional:
-        # it makes reruns idempotent when the same segment ids already have a "base"
-        # layer instead of failing halfway through catalog startup.
-        dataset.register(uris, layer_name="base", on_duplicate=OnDuplicateSegmentLayer.REPLACE).wait()
         _register_default_dataset_blueprint(
             server,
             dataset,

--- a/simplecv/data/exoego/hot3d.py
+++ b/simplecv/data/exoego/hot3d.py
@@ -115,7 +115,35 @@ class Hot3dSequence(BaseExoEgoSequence[Hot3dConfig]):
 
         return stream_ts
 
-    def load_labels(self) -> ExoEgoLabels:
+    @staticmethod
+    def _has_hand_labels(seq_dir: Path) -> bool:
+        """Return whether this sequence has usable hand pose labels."""
+        metadata_path: Path = seq_dir / "metadata.json"
+        has_hand_gt: bool | None = None
+        if metadata_path.exists():
+            metadata: dict = json.loads(metadata_path.read_text())
+            if "have_hand_object_pose_gt" in metadata:
+                has_hand_gt = bool(metadata["have_hand_object_pose_gt"])
+
+        if has_hand_gt is False:
+            return False
+
+        required_paths: tuple[Path, ...] = (
+            seq_dir / "umetrack_hand_user_profile.json",
+            seq_dir / "umetrack_hand_pose_trajectory.jsonl",
+        )
+        missing_or_empty: list[Path] = [
+            path for path in required_paths if not path.exists() or path.stat().st_size == 0
+        ]
+        if not missing_or_empty:
+            return True
+
+        if has_hand_gt is True:
+            missing_text: str = ", ".join(str(path) for path in missing_or_empty)
+            raise AssertionError(f"Hand GT is marked available but required label files are missing or empty: {missing_text}")
+        return False
+
+    def load_labels(self) -> ExoEgoLabels | None:
         """Load COCO-133 hand keypoints in meters from HOT3D UmeTrack annotations.
 
         HOT3D stores hand annotations in UmeTrack JSONL format:
@@ -127,6 +155,8 @@ class Hot3dSequence(BaseExoEgoSequence[Hot3dConfig]):
         mm before FK, then scale the output back to meters.
         """
         seq_dir: Path = self._sequence_dir()
+        if not self._has_hand_labels(seq_dir):
+            return None
 
         # ── Load hand model ──────────────────────────────────────────────
         profile_path: Path = seq_dir / "umetrack_hand_user_profile.json"
@@ -302,7 +332,7 @@ class Hot3dSequence(BaseExoEgoSequence[Hot3dConfig]):
         from scipy.spatial.transform import Rotation
 
         mano_path: Path = seq_dir / "mano_hand_pose_trajectory.jsonl"
-        if not mano_path.exists():
+        if not mano_path.exists() or mano_path.stat().st_size == 0:
             return None
 
         # JSONL: one JSON object per line. pyserde doesn't support JSONL natively,
@@ -314,6 +344,8 @@ class Hot3dSequence(BaseExoEgoSequence[Hot3dConfig]):
                 line = line.strip()
                 if line:
                     mano_frames.append(json.loads(line))
+        if not mano_frames:
+            return None
 
         # Filter to same RGB-aligned indices as UmeTrack
         mano_filtered: list[dict] = [mano_frames[int(i)] for i in rgb_label_indices]

--- a/tests/test_exoego_catalog.py
+++ b/tests/test_exoego_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -202,6 +203,35 @@ def test_catalog_config_defaults_to_general_catalog_index() -> None:
 )
 def test_table_name_for_dataset(dataset_name: str, table_name: str) -> None:
     assert table_name_for_dataset(dataset_name) == table_name
+
+
+def test_hot3d_has_hand_labels_respects_no_gt_metadata(tmp_path: Path) -> None:
+    seq_dir: Path = tmp_path / "P0016_0ca96b7b"
+    seq_dir.mkdir()
+    (seq_dir / "metadata.json").write_text(json.dumps({"have_hand_object_pose_gt": False}))
+
+    assert Hot3dSequence._has_hand_labels(seq_dir) is False
+
+
+def test_hot3d_has_hand_labels_rejects_empty_files_when_gt_available(tmp_path: Path) -> None:
+    seq_dir: Path = tmp_path / "P0015_e7458eb3"
+    seq_dir.mkdir()
+    (seq_dir / "metadata.json").write_text(json.dumps({"have_hand_object_pose_gt": True}))
+    (seq_dir / "umetrack_hand_user_profile.json").touch()
+    (seq_dir / "umetrack_hand_pose_trajectory.jsonl").touch()
+
+    with pytest.raises(AssertionError, match="Hand GT is marked available"):
+        Hot3dSequence._has_hand_labels(seq_dir)
+
+
+def test_hot3d_has_hand_labels_accepts_nonempty_gt_files(tmp_path: Path) -> None:
+    seq_dir: Path = tmp_path / "P0015_e7458eb3"
+    seq_dir.mkdir()
+    (seq_dir / "metadata.json").write_text(json.dumps({"have_hand_object_pose_gt": True}))
+    (seq_dir / "umetrack_hand_user_profile.json").write_text("{}")
+    (seq_dir / "umetrack_hand_pose_trajectory.jsonl").write_text("{}\n")
+
+    assert Hot3dSequence._has_hand_labels(seq_dir) is True
 
 
 class _FakeSegmentTable:


### PR DESCRIPTION
## Summary
- Mount catalog datasets at server startup to reduce registration pressure for large RRD roots while preserving segment URLs.
- Treat Hot3D sequences with missing or empty hand label files as unlabeled when metadata indicates no GT, and fail clearly when GT is declared but required files are empty.
- Add tests for Hot3D hand-label availability handling.

## Validation
- `pixi run tests tests/test_exoego_catalog.py` passed: 39 tests.
- `pixi run -e dev ruff check simplecv/apis/exoego_forge_catalog.py simplecv/data/exoego/hot3d.py tests/test_exoego_catalog.py` passed.
- `pixi run lint` still fails on pre-existing unrelated issues in notebooks and other modules.