### PR TITLE
[codex] Default catalog task to mounted RRD root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ cmd = "python tools/preprocess_aria_gen2_pilot.py"
 description = "Convert Aria Gen2 Pilot VRS files to AV1 MP4 for simplecv"
 
 [tool.pixi.tasks.catalog]
-cmd = "python tools/catalog.py"
+cmd = "python tools/catalog.py --rrd-root /mnt/8tb/data/exoego-forge-catalog --no-optimize-for-catalog"
 description = "Host the ExoEgo Forge RRD catalog index"
 
 [tool.pixi.tasks._download-example-polycam-data]


### PR DESCRIPTION
## Summary
- Update `pixi run catalog` to mount `/mnt/8tb/data/exoego-forge-catalog` by default.
- Add `--no-optimize-for-catalog` to avoid creating another cache when using the already optimized catalog RRD root.

## Validation
- `pixi run catalog --help` shows the task expands to `python tools/catalog.py --rrd-root /mnt/8tb/data/exoego-forge-catalog --no-optimize-for-catalog --help`.

## Notes
- This is a follow-up to the merged Hot3D/catalog branch and only changes `pyproject.toml`.