### PR TITLE
Add EPFL-Smart-Kitchen ExoEgo dataset support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.codex/skills/add-exoego-dataset/SKILL.md
+++ b/.codex/skills/add-exoego-dataset/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: add-exoego-dataset
+description: Add or update SimpleCV ExoEgo dataset adapters end to end. Use when implementing a dataset loader, mapping labels to COCO-133, storing MANO/depth metadata, saving RRDs, registering ExoEgo Forge catalog entries, serving the Rerun catalog/web viewer, or validating screenshots.
+---
+
+# Add ExoEgo Dataset
+
+Keep this skill short: read the repo, copy local patterns, prove the result visually, and avoid inventing parallel tooling.
+
+## Read First
+
+- Task/goal doc, if present.
+- `AGENTS.md`, `pyproject.toml`, and `docs/exoego_schema.md`.
+- Closest existing adapter: usually HOCap for ego+exo+MANO, Assembly101 for multi-view hand keypoints, HOT3D for headset+MANO, or Aria/EgoDex for ego-only.
+- Existing entrypoints before adding new ones: `view_exoego.py`, `batch_raw_to_rrd.py`, and `exoego_forge_catalog.py`.
+
+## Workflow
+
+- Use Pixi and TDD. Build vertical slices: identity/config, discovery count, `load_labels=False`, labels, optional MANO/depth/mesh, single RRD, catalog, full conversion, screenshots.
+- Inspect real files early. Trust headers and sample arrays over docs for names, capitalization, timestamps, units, and shapes.
+- Prefer the established three-file split for ego+exo datasets: `data/exoego/<dataset>.py`, `data/ego/<dataset>_ego.py`, `data/exo/<dataset>_exo.py`.
+- Add `SequenceIdentity`, config `_target`, stream timestamps, `load_labels`, dataset iteration/counting, `dataset_defaults`, and catalog defaults when full registration is in scope.
+- Do not add dataset-specific viewer/catalog scripts. Use generic view, batch conversion, and `tools/catalog.py`.
+
+## Labels And MANO
+
+- End state for labels is `ExoEgoLabels.xyzc_stack: Float[np.ndarray, "num_frames 133 4"]`; missing points are `NaN xyz` with `0.0` confidence.
+- COCO-133 rows: body `0:17`, feet `17:23`, face `23:91`, left hand `91:112`, right hand `112:133`.
+- Use released 3D keypoints when available. Store MANO/SMPL parameters separately; do not generate COCO labels from MANO/SMPL unless this repo already has a tested conversion for that exact source.
+- `ManoStack` convention is hand `0=right`, `1=left`. If a dataset has one shared shape requirement but per-hand shapes differ, follow the user/local precedent and warn rather than fail.
+- Verify hand order from upstream code or links before reordering. Apply MANO-to-COCO reorder only to raw MANO joints, not released COCO-ordered hand keypoints.
+
+## Rerun And Catalog Lessons
+
+- Log video through the shared `log_video` path so recordings use video streams, not ad hoc asset-video logging.
+- Tune `image_plane_distance` from screenshots; overlapping camera frusta usually mean it is too large.
+- For browser sharing, use one SimpleCV catalog command but expose two endpoints: web viewer port and catalog server port. Tailscale raw TCP forwarding worked where HTTPS proxying caused malformed catalog responses.
+- Rerun directory dataset registration expects direct child `.rrd` files. For nested datasets, register a flat hardlink mirror so built-in dataset tables show rows.
+- If AV1/Hugging Face mirroring is in scope, transcode videos first, prefer NVENC when available, register against AV1 paths, and skip sidecars made obsolete by the mirror.
+
+## Done Means
+
+- Focused tests pass, including catalog tests for defaults, camera names, table names, and nested RRD discovery.
+- A representative sequence opens with no labels, then with labels, then as an RRD.
+- Full conversion covers every supported session; every skip has a written reason.
+- Native Rerun screenshots show direct viewer, labels/MANO when present, catalog table rows, and clicked recordings.

--- a/.codex/skills/add-exoego-dataset/agents/openai.yaml
+++ b/.codex/skills/add-exoego-dataset/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Add ExoEgo Dataset"
+  short_description: "Implement a SimpleCV ExoEgo dataset adapter end to end."
+  default_prompt: "Add a new SimpleCV ExoEgo dataset using TDD, COCO-133 labels, viewer validation, RRD conversion, and catalog registration."

--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,6 @@ pretrained_models/*
 /.codex/config.toml.bak
 /.vscode/mcp.json
 /.vscode/mcp.json.bak
-/AGENTS.md
 /AGENTS.md.bak
 # END Ruler Generated Files
 artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repo Instructions
+
+## Package Manager
+
+Use Pixi for all project commands. Do not use `pip` or `uv` in this repo.
+
+## Implementation Workflow
+
+Use the `tdd` skill for implementation work. Prefer a failing or characterization
+test first, then make the smallest change that proves the behavior.
+
+## Existing Pattern First
+
+Before adding new infrastructure, inspect the closest existing implementation and
+preserve its default behavior unless there is a demonstrated blocker.
+
+For catalog/server changes:
+
+- Do not replace the existing `tools/catalog.py` / `exoego_forge_catalog.py` flow
+  with a parallel implementation.
+- Assembly101-style nested RRD registration must continue to work through
+  recursive discovery and explicit RRD file lists.
+- Transport-specific workarounds must be opt-in and covered by tests proving the
+  normal path is unchanged.
+
+## Python Style
+
+- Use PEP 526-style variable annotations for nontrivial local values.
+- Annotate arrays with jaxtyping dtype and shape.
+- Follow the repo's existing dataclass field documentation style.

--- a/pixi.lock
+++ b/pixi.lock
@@ -2896,507 +2896,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/2b/783f02668e6e21849abd4d40ea28475d7c587ce6e919cf3ce17314b4c031/vrs-1.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/ca/75fac5856ab5cfa51bbbcefa250182e50441074fdc3f803f6e76451fab43/dataclasses-0.8-py3-none-any.whl
-  rerun-prerelease:
-    channels:
-    - url: https://prefix.dev/conda-forge/
-    indexes:
-    - https://pypi.org/simple
-    packages:
-      linux-64:
-      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/assimp-5.4.3-hecf2907_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/av-15.1.0-py312hdd571cc_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.9.0-h92a005d_16.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.2-he7b75e1_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.4-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.1-h92c474e_6.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.5.5-h0c2b49e_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.2-hee85082_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.21.0-h1d8da38_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.13.1-h46c1de9_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.8.3-h9cdc349_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h92c474e_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.7-h92c474e_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.32.10-h186f887_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h379b65b_14.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.1.0-py312h1289d80_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/embree-4.3.3-h3173236_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/expat-2.8.0-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h0b79d52_704.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/fmt-11.0.2-h07f6e7f_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-h215f996_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/frozendict-2.4.7-py312h4c3975b_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/glfw-3.4-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.13.0-nompi_py312hedeef09_100.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-11.0.0-h76408a6_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_109.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.4-hb700be7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-20.0.0-h1b9301b_8_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_8_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_8_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_8_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.3-h52826cd_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.3.0-h766b0b6_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.9.0-37_h5875eb1_mkl.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libboost-1.88.0-hed09d94_6.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.9.0-37_hfef963f_mkl.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_15.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.84.0-h2ff4ddf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-2.36.0-hc4361e1_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-2.36.0-h0121fbd_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.71.0-h8e591d7_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libheif-1.19.7-gpl_hc18d805_100.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.9.0-37_h5e43f62_mkl.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.9.0-37_hdba1596_mkl.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h00e09a9_116.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.11.0-qt6_py312ha9b1755_604.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hd1b1c89_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2025.0.0-hdc3f47d_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.0.0-h4d9b6c2_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2025.0.0-h4d9b6c2_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2025.0.0-h981d57b_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.0.0-hdc3f47d_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.0.0-hdc3f47d_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.0.0-hdc3f47d_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2025.0.0-h981d57b_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2025.0.0-h0e684df_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2025.0.0-h0e684df_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.0.0-h5888daf_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.0.0-h684f15b_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.0.0-h5888daf_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_8_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.06.26-hba17884_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.7.1-cpu_mkl_h783a78b_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.9-h84d6215_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libutf8proc-2.10.0-h202a827_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.11.0-he8b52b9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.9-h04c0eec_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.4-h4922eb0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/multiprocess-0.70.16-py312h66e93f0_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_6.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/open3d-0.18.0-py312h3493b20_14.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.3.5-h09fa569_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/orc-2.1.2-h17f744e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.3-h9ac818e_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.44-hc749103_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.11.0-qt6_py312h0412312_604.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-20.0.0-py312h7900ff3_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-core-20.0.0-py312hc195796_2_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/python-xxhash-3.6.0-py312h0d868a3_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.7.1-cpu_mkl_py312_he6f58a3_102.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.8.3-h6441bc3_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.06.26-h9925aae_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.12.12-h718f522_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.5.22-h96f233e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.54-h3f2d84a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.2.14-he3e324a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-3.0.2-h5888daf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2021.13.0-h8d10470_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tinyobjloader-1.0.7-h54a6638_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.8.1-cpu_py312_hfd9ddb6_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.24.0-cpu_py312_h56cfa8b_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-extra-decoders-0.0.2-py312hd1393df_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.5-py312h4c3975b_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.3.1-qt_py312h6cb585f_216.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.21.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/dash-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/datasets-4.0.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/dill-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/einops-0.8.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/flask-3.1.3-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2025.3.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-0.27.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.4-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/icecream-2.2.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.18.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.5.7-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pyarrow-stubs-20.0.0.20251215-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.29.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-3.2.1-pyh332efcf_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/retrying-1.4.2-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
-      - conda: https://prefix.dev/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/types-requests-2.33.0.20260508-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/types-tqdm-4.67.3.20260508-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
-      - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.6-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
-      - pypi: .
-      - pypi: git+https://github.com/pablovela5620/rtmlib.git?rev=98bca2193c39b349034b280803b54c9ee58f7c68#98bca2193c39b349034b280803b54c9ee58f7c68
-      - pypi: git+https://github.com/pablovela5620/wilor-nano.git?rev=70d01f333960113f825d2f7994a85fce5c51d61a#70d01f333960113f825d2f7994a85fce5c51d61a
-      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/37/ee/478689c69b3cb1ccabb2d52feac0c181f6cdf20b51a81df35344b1dab9a6/datafusion-52.3.0-cp310-abi3-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/37/f4/84309ba0a69ba2b4d00b41bcd3c72a8f36865458ce9404b17ad5d2857ef1/vrs-1.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/3f/35f4041a82a68df89fe4af97c8bb44aa492dad924799cbb02078e9e303e6/s3fs-2025.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4e/4e/21cd0b8f365449f1576f93de1ec8718ed18a7a3bc086dfbdeb79437bba7a/botocore-1.41.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/a6/1d63b51f2fb9b1f4153ac7c1e2c6d12da37fef1600d045ba1771c396d17f/rerun_sdk-0.32.0-cp310-abi3-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/68/99/2018622d268f6017ddfa5ee71f070bad5d07590374793166baa102849d17/timm-0.9.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/74/af3e40919305f16968ea3ab88d84b511d710dd281eb5dafaf4897579dd22/ultralytics_thop-2.0.19-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/76/08/744f31ba3d9fd2f484b2da8e9d2084f8b7bde3d1f8b7c51b1989d66c8994/ultralytics-8.3.162-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/81/69/87efc2482aab172a32e4147eb5666ebc2e4c875e17d3104878553720a83a/pytest_beartype-0.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/96/9c/c86a018d1cbb3c117f7a83fcc86e74b648edaeacc849b8dbc71dd84171bf/fastcore-1.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b4/af/ce4df3ca29122d219c45d3e86e5ff9a9df03b8cf31afd76817b662c803a3/tifffile-2026.5.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/58/3bf0b7d474607dc7fd67dd1365c4e0f392c8177eaf4054e5ddee3ebd53b5/aiobotocore-2.26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/be/cc/320798a96109bfd7cc4cb8d40431faa0b90256b5123f80ffc08ca98eaf18/lovely_numpy-0.2.23-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d6/d8/f87ea6f42456254b48915970ed98e993110521e9263472840174d32c880d/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d7/c6/efd96866c457f22d1e893f9ac67f17ff61a5661ad2a061da61657e9c4999/pyturbojpeg-2.2.0.tar.gz
-      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/52/a63ad6df0d74ca74019b4f4498a5a00483cdaf2e5f17efea261d1f05e3b8/ipython_beartype-0.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f2/5d/865e17349564eb1772688d8afc5e3081a5964c640d64d1d2880ebaed002d/typing-3.10.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/ca/75fac5856ab5cfa51bbbcefa250182e50441074fdc3f803f6e76451fab43/dataclasses-0.8-py3-none-any.whl
   t265:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -3711,27 +3210,6 @@ packages:
   - pkg:pypi/aiohttp?source=hash-mapping
   size: 1022914
   timestamp: 1767525761337
-- conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
-  sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
-  md5: 68edaee7692efb8bbef5e95375090189
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aiohappyeyeballs >=2.5.0
-  - aiosignal >=1.4.0
-  - attrs >=17.3.0
-  - frozenlist >=1.1.1
-  - libgcc >=14
-  - multidict >=4.5,<7.0
-  - propcache >=0.2.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - yarl >=1.17.0,<2.0
-  license: MIT AND Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/aiohttp?source=hash-mapping
-  size: 1034187
-  timestamp: 1775000054521
 - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
   sha256: b9214bc17e89bf2b691fad50d952b7f029f6148f4ac4fe7c60c08f093efdf745
   md5: 76df83c2a9035c54df5d04ff81bcc02d
@@ -3754,17 +3232,6 @@ packages:
   purls: []
   size: 584398
   timestamp: 1767969626545
-- conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
-  md5: dcdc58c15961dbf17a0621312b01f5cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  license_family: GPL
-  purls: []
-  size: 584660
-  timestamp: 1768327524772
 - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
@@ -4212,17 +3679,6 @@ packages:
   purls: []
   size: 260341
   timestamp: 1757437258798
-- conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
-  md5: d2ffd7602c02f2b316fd921d39876885
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 260182
-  timestamp: 1771350215188
 - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
   sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
   md5: 920bb03579f15389b9e512095ad995b7
@@ -4288,22 +3744,6 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 296986
   timestamp: 1758716192805
-- conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-  sha256: 7dafe8173d5f94e46cf9cd597cc8ff476a8357fbbd4433a8b5697b2864845d9c
-  md5: 648ee28dcd4e07a1940a17da62eccd40
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 295716
-  timestamp: 1761202958833
 - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_16.conda
   sha256: 387cd20bc18c9cabae357fec1b73f691b8b6a6bafbf843b8ff17241eae0dd1d5
   md5: 77e54ea3bd0888e65ed821f19f5d23ad
@@ -4664,18 +4104,6 @@ packages:
   purls: []
   size: 760229
   timestamp: 1685695754230
-- conda: https://prefix.dev/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
-  sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-  md5: ecfff944ba3960ecb334b9a2663d708d
-  depends:
-  - expat >=2.4.2,<3.0a0
-  - libgcc-ng >=9.4.0
-  - libglib >=2.70.2,<3.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 618596
-  timestamp: 1640112124844
 - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
   sha256: 3b988146a50e165f0fa4e839545c679af88e4782ec284cc7b6d07dd226d6a068
   md5: 679616eb5ad4e521c83da4650860aba7
@@ -4722,21 +4150,6 @@ packages:
   - pkg:pypi/debugpy?source=hash-mapping
   size: 2856928
   timestamp: 1765704062579
-- conda: https://prefix.dev/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
-  sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
-  md5: ee1b48795ceb07311dd3e665dd4f5f33
-  depends:
-  - python
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/debugpy?source=hash-mapping
-  size: 2858582
-  timestamp: 1769744978783
 - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
   sha256: 1bcc132fbcc13f9ad69da7aa87f60ea41de7ed4d09f3a00ff6e0e70e1c690bc2
   md5: bfd56492d8346d669010eccafe0ba058
@@ -4762,75 +4175,6 @@ packages:
   purls: []
   size: 9650435
   timestamp: 1721696428474
-- conda: https://prefix.dev/conda-forge/linux-64/expat-2.8.0-hecca717_0.conda
-  sha256: ca4dc1da00a8aaa56c1088e7f45f1859ecea6f75874e67584f1af6e5cf8179f8
-  md5: 992e529e407c9d67d50be1d7543fde4c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat 2.8.0 hecca717_0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 148114
-  timestamp: 1777846120303
-- conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h0b79d52_704.conda
-  sha256: b8f13b9a670719690275556c6b82cc8d7811b9c406aae882389591559c1f1df8
-  md5: b0cb34bcec7bb0e6f173579088fa1316
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.13,<1.3.0a0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.13.3,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=11.0.0,<12.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libgcc >=13
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.6.4,<6.0a0
-  - libopenvino >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-hetero-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-npu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-ir-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-onnx-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-paddle-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-pytorch-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - librsvg >=2.58.4,<3.0a0
-  - libstdcxx >=13
-  - libva >=2.22.0,<3.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.7,<2.14.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.4.1,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - sdl2 >=2.32.50,<3.0a0
-  - svt-av1 >=3.0.2,<3.0.3.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  constrains:
-  - __cuda  >=12.4
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 10376030
-  timestamp: 1743376866080
 - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
   sha256: e8e93a1afd93bed11ccf2a2224d2b92b2af8758c89576ed87ff4df7f3269604f
   md5: 28cffcba871461840275632bc4653ce3
@@ -4978,43 +4322,6 @@ packages:
   purls: []
   size: 265599
   timestamp: 1730283881107
-- conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
-  sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
-  md5: 867127763fbe935bab59815b6e0b7b5c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libuuid >=2.41.3,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 270705
-  timestamp: 1771382710863
-- conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-h215f996_4.conda
-  sha256: f94040a0d7c449038811097e145f223bd3b2ab4c5181870c6e27e1b9dd777d48
-  md5: b39dccf5af984bcb68ee2aa0f3213ea6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglu >=9.0.3,<9.1.0a0
-  - libstdcxx >=14
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - xorg-libxi >=1.8.2,<2.0a0
-  - xorg-libxxf86vm >=1.1.7,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 146159
-  timestamp: 1776928018299
 - conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
   sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
   md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
@@ -5042,16 +4349,6 @@ packages:
   purls: []
   size: 173114
   timestamp: 1757945422243
-- conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
-  sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
-  md5: 8462b5322567212beeb025f3519fb3e2
-  depends:
-  - libfreetype 2.14.3 ha770c72_0
-  - libfreetype6 2.14.3 h73754d4_0
-  license: GPL-2.0-only OR FTL
-  purls: []
-  size: 173839
-  timestamp: 1774298173462
 - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
   sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
   md5: f9f81ea472684d75b9dd8d0b328cf655
@@ -5158,20 +4455,6 @@ packages:
   purls: []
   size: 579311
   timestamp: 1754960116630
-- conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
-  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
-  depends:
-  - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 528149
-  timestamp: 1715782983957
 - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
   sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
   md5: c379d67c686fb83475c1a6ed41cc41ff
@@ -5210,21 +4493,6 @@ packages:
   purls: []
   size: 77248
   timestamp: 1712692454246
-- conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
-  sha256: e28a214c71590a09f75f1aaccf5795bbcfb99b00c2d6ef55d34320b4f47485bd
-  md5: 787c780ff43f9f79d78d01e476b81a7c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 75835
-  timestamp: 1773985381918
 - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
   sha256: 68f071ea25e79ee427c0d6c35ccc137d66f093a37660a4e41bafe0c49d64f2d6
   md5: 00e642ec191a19bf806a3915800e9524
@@ -5320,23 +4588,6 @@ packages:
   - pkg:pypi/gmpy2?source=hash-mapping
   size: 214554
   timestamp: 1762946924209
-- conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
-  sha256: 6fbdd686d04a0d8c48efe92795137d3bba55a4325acd7931978fd8ea5e24684d
-  md5: fedbe80d864debab03541e1b447fc12a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gmp >=6.3.0,<7.0a0
-  - libgcc >=14
-  - mpc >=1.3.1,<2.0a0
-  - mpfr >=4.2.1,<5.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls:
-  - pkg:pypi/gmpy2?source=hash-mapping
-  size: 253171
-  timestamp: 1773245116314
 - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
   sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
   md5: 2cd94587f3a401ae05e03a6caf09539d
@@ -5400,25 +4651,6 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1388165
   timestamp: 1739952623855
-- conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-11.0.0-h76408a6_0.conda
-  sha256: 9d33201d3e12a61d4ea4b1252a3468afb18b11a418f095dceffdf09bc6792f59
-  md5: 347cb348bfc8d77062daee11c326e518
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - freetype >=2.13.3,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libgcc >=13
-  - libglib >=2.84.0,<3.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1720702
-  timestamp: 1743082646624
 - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-11.4.5-h15599e2_0.conda
   sha256: 9d0d74858e8f8b76f6d3bf11a7390e6eb18eb743dd6e5fd7c4e9822634556f6d
   md5: 1276ae4aa3832a449fcb4253c30da4bc
@@ -5586,22 +4818,6 @@ packages:
   purls: []
   size: 681643
   timestamp: 1754514437930
-- conda: https://prefix.dev/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
-  sha256: a6a9858eadb4c794b56a1c954c1d4f4b57d96c9fb87092dd46f5bff9b0697b35
-  md5: 115ecf05370670f93bc81a8c4f7fd57f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - freeglut >=3.2.2,<4.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglu >=9.0.3,<10.0a0
-  - libglu >=9.0.3,<9.1.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  license: JasPer-2.0
-  purls: []
-  size: 684185
-  timestamp: 1773677703432
 - conda: https://prefix.dev/conda-forge/linux-64/jasper-4.2.9-he3c4edf_0.conda
   sha256: cea4c90ca4971cbc29d5930301cabcc581a781fd26d0cc7ca0aa459cb33ff573
   md5: 5455c1a77c2aa337f04d94ff0ef413c3
@@ -5688,19 +4904,6 @@ packages:
   purls: []
   size: 249959
   timestamp: 1768184673131
-- conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_0.conda
-  sha256: eb89c6c39f2f6a93db55723dbb2f6bba8c8e63e6312bf1abf13e6e9ff45849c8
-  md5: f92f984b558e6e6204014b16d212b271
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 251086
-  timestamp: 1778079286384
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
   sha256: 9e191baf2426a19507f1d0a17be0fdb7aa155cdf0f61d5a09c808e0a69464312
   md5: a6abd2796fc332536735f68ba23f7901
@@ -5727,19 +4930,6 @@ packages:
   purls: []
   size: 730831
   timestamp: 1766513089214
-- conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
-  md5: 18335a698559cdbcd86150a48bf54ba6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-64 2.45.1
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 728002
-  timestamp: 1774197446916
 - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
   sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
   md5: 9344155d33912347b37f0ae6c410a835
@@ -5752,18 +4942,6 @@ packages:
   purls: []
   size: 264243
   timestamp: 1745264221534
-- conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-  sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
-  md5: a752488c68f2e7c456bcbd8f16eec275
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 261513
-  timestamp: 1773113328888
 - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.26.1-hb700be7_0.conda
   sha256: 070cade1dec8f1352b26282c17a21df20c5ff7b58444a686222f5073cc904b7b
   md5: d5d28ca40c9aefdb7617e8cdb7c218c2
@@ -5788,18 +4966,6 @@ packages:
   purls: []
   size: 667437
   timestamp: 1766226025812
-- conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.4-hb700be7_0.conda
-  sha256: ed1eb569df9bbfcb4b451478eaba03cbd2d26efed88152ad2e4b7b7b2297ef84
-  md5: c44c0485271b7b4c92dec39e9f7d096e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 858263
-  timestamp: 1777157859593
 - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
   sha256: 65d5ca837c3ee67b9d769125c21dc857194d7f6181bb0e7bd98ae58597b457d0
   md5: 00290e549c5c8a32cc271020acc9ec6b
@@ -6345,17 +5511,6 @@ packages:
   purls: []
   size: 121429
   timestamp: 1762349484074
-- conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
-  sha256: 37c41b1024d0c75da76822e3c079aabaf121618a32fe05e53a897b35a88008fc
-  md5: 499cd8e2d4358986dbe3b30e8fe1bf6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 124432
-  timestamp: 1774333989027
 - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-4_h0358290_openblas.conda
   build_number: 4
   sha256: 7abc88e2fdccddab27d2a889b9c9063df84a05766cc24828c9b5ca879f25c92c
@@ -6401,19 +5556,6 @@ packages:
   purls: []
   size: 21292259
   timestamp: 1773110979919
-- conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_15.conda
-  sha256: 4581c97a00e61b0f3332bcb5cac0d2f8121dfa20fb81c4b1ffbdd12412c8f4da
-  md5: 9981b5fa5a35796827027aad4949a63e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libllvm20 >=20.1.8,<20.2.0a0
-  - libstdcxx >=14
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 21292403
-  timestamp: 1776983019123
 - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_5.conda
   sha256: b9f0e167cdf5cbe076231788fcb3affe25914534d84ab249258161b693c4cfd2
   md5: 33acc83688f092f96ea2ead08e3b4dcd
@@ -6857,19 +5999,6 @@ packages:
   purls: []
   size: 76643
   timestamp: 1763549731408
-- conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
-  sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
-  md5: a3b390520c563d78cc58974de95a03e5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - expat 2.8.0.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 77241
-  timestamp: 1777846112704
 - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
   sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
   md5: ede4673863426c0883c0063d853bbd85
@@ -6881,17 +6010,6 @@ packages:
   purls: []
   size: 57433
   timestamp: 1743434498161
-- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
-  md5: a360c33a5abe61c07959e449fa1453eb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 58592
-  timestamp: 1769456073053
 - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
   sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
   md5: 47595b9d53054907a00d95e4d47af1d6
@@ -6915,15 +6033,6 @@ packages:
   purls: []
   size: 7664
   timestamp: 1757945417134
-- conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-  sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
-  md5: e289f3d17880e44b633ba911d57a321b
-  depends:
-  - libfreetype6 >=2.14.3
-  license: GPL-2.0-only OR FTL
-  purls: []
-  size: 8049
-  timestamp: 1774298163029
 - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
   sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
   md5: 8e7251989bca326a28f4a5ffbd74557a
@@ -6938,20 +6047,6 @@ packages:
   purls: []
   size: 386739
   timestamp: 1757945416744
-- conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-  sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
-  md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  constrains:
-  - freetype >=2.14.3
-  license: GPL-2.0-only OR FTL
-  purls: []
-  size: 384575
-  timestamp: 1774298162622
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
   sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
   md5: 6d0363467e6ed84f11435eb309f2ff06
@@ -6965,20 +6060,6 @@ packages:
   purls: []
   size: 1042798
   timestamp: 1765256792743
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-  sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
-  md5: 0aa00f03f9e39fb9876085dee11a85d4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_18
-  - libgomp 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 1041788
-  timestamp: 1771378212382
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
   sha256: 5f07f9317f596a201cc6e095e5fc92621afca64829785e483738d935f8cab361
   md5: 5a68259fac2da8f2ee6f7bfe49c9eb8b
@@ -6988,16 +6069,6 @@ packages:
   purls: []
   size: 27256
   timestamp: 1765256804124
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
-  md5: d5e96b1ed75ca01906b3d2469b4ce493
-  depends:
-  - libgcc 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 27526
-  timestamp: 1771378224552
 - conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
   sha256: 50a9e9815cf3f5bce1b8c5161c0899cc5b6c6052d6d73a4c27f749119e607100
   md5: 2f4de899028319b27eb7a4023be5dfd2
@@ -7069,22 +6140,6 @@ packages:
   purls: []
   size: 134712
   timestamp: 1731330998354
-- conda: https://prefix.dev/conda-forge/linux-64/libglib-2.84.0-h2ff4ddf_0.conda
-  sha256: 8e8737ca776d897d81a97e3de28c4bb33c45b5877bbe202b9b0ad2f61ca39397
-  md5: 40cdeafb789a5513415f7bdbef053cf5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - libiconv >=1.18,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.84.0 *_0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 3998765
-  timestamp: 1743038881905
 - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.84.3-hf39c6af_0.conda
   sha256: e1ad3d9ddaa18f95ff5d244587fd1a37aca6401707f85a37f7d9b5002fcf16d0
   md5: 467f23819b1ea2b89c3fc94d65082301
@@ -7295,18 +6350,6 @@ packages:
   purls: []
   size: 633710
   timestamp: 1762094827865
-- conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
-  sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
-  md5: 6178c6f2fb254558238ef4e6c56fb782
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  purls: []
-  size: 633831
-  timestamp: 1775962768273
 - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.1-hf08fa70_5.conda
   sha256: 6b9524a6a7ea6ef1ac791b697f660c2898171ae505d12e6d27509b59cf059ee6
   md5: 82954a6f42e3fba59628741dca105c98
@@ -7455,18 +6498,6 @@ packages:
   purls: []
   size: 112894
   timestamp: 1749230047870
-- conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
-  md5: b88d90cad08e6bc8ad540cb310a761fb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - xz 5.8.3.*
-  license: 0BSD
-  purls: []
-  size: 113478
-  timestamp: 1775825492909
 - conda: https://prefix.dev/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
   sha256: 329e66330a8f9cbb6a8d5995005478188eb4ba8a6b6391affa849744f4968492
   md5: f61edadbb301530bd65a32646bd81552
@@ -7557,23 +6588,6 @@ packages:
   purls: []
   size: 666600
   timestamp: 1756834976695
-- conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-  sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
-  md5: 2a45e7f8af083626f009645a6481f12d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - c-ares >=1.34.6,<2.0a0
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 663344
-  timestamp: 1773854035739
 - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
   sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
   md5: db63358239cbe1ff86242406d440e44a
@@ -7678,61 +6692,6 @@ packages:
   purls: []
   size: 5927939
   timestamp: 1763114673331
-- conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.11.0-qt6_py312ha9b1755_604.conda
-  sha256: b3756ac98925a30689747b4deb82124e186c064cc71afc2423dbeb80a4effd71
-  md5: 321b54902c4473b70afde2601a4062dc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  - ffmpeg >=7.1.1,<8.0a0
-  - freetype >=2.13.3,<3.0a0
-  - harfbuzz >=11.0.0,<12.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.2.5,<5.0a0
-  - libasprintf >=0.23.1,<1.0a0
-  - libavif16 >=1.2.1,<2.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.0,<3.0a0
-  - libgcc >=13
-  - libgettextpo >=0.23.1,<1.0a0
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.84.0,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-hetero-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-npu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-ir-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-onnx-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-paddle-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-pytorch-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.0.0,<2025.0.1.0a0
-  - libpng >=1.6.47,<1.7.0a0
-  - libprotobuf >=5.29.3,<5.29.4.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.5.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.3.3,<3.4.0a0
-  - qt6-main >=6.8.3,<6.9.0a0
-  constrains:
-  - imath<3.2.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 30829355
-  timestamp: 1743561787321
 - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.11.0-qt6_py312ha9b1755_605.conda
   sha256: 31c2b5fc1a357bc0b433e5d643ea58ae4a2eddb1daed93031724db0b68a7547e
   md5: 83010f6ff225854a910d39b239f56ad8
@@ -8225,17 +7184,6 @@ packages:
   purls: []
   size: 312472
   timestamp: 1744330953241
-- conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
-  sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
-  md5: 2446ac1fe030c2aa6141386c1f5a6aed
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 324993
-  timestamp: 1768497114401
 - conda: https://prefix.dev/conda-forge/linux-64/libparquet-19.0.1-h081d1f1_16_cpu.conda
   build_number: 16
   sha256: 7a5dd75e60f387936e538b35fb7001f5264d5f18a5573e38e4d31662ee0e8302
@@ -8308,17 +7256,6 @@ packages:
   purls: []
   size: 317748
   timestamp: 1764981060755
-- conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-  sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
-  md5: eba48a68a1a2b9d3c0d9511548db85db
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.2,<2.0a0
-  license: zlib-acknowledgement
-  purls: []
-  size: 317729
-  timestamp: 1776315175087
 - conda: https://prefix.dev/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
   sha256: 06a8ace6cc5ee47b85a5e64fad621e5912a12a0202398f54f302eb4e8b9db1fd
   md5: a4769024afeab4b32ac8167c2f92c7ac
@@ -8503,17 +7440,6 @@ packages:
   purls: []
   size: 939312
   timestamp: 1768147967568
-- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
-  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
-  md5: 7dc38adcbf71e6b38748e919e16e0dce
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.2,<2.0a0
-  license: blessing
-  purls: []
-  size: 954962
-  timestamp: 1777986471789
 - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -8539,19 +7465,6 @@ packages:
   purls: []
   size: 5856456
   timestamp: 1765256838573
-- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-  sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
-  md5: 1b08cd684f34175e4514474793d44bcb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_18
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 5852330
-  timestamp: 1771378262446
 - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
   sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
   md5: 1b3152694d236cf233b76b8c56bf0eae
@@ -8561,16 +7474,6 @@ packages:
   purls: []
   size: 27300
   timestamp: 1765256885128
-- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
-  md5: 6235adb93d064ecdf3d44faee6f468de
-  depends:
-  - libstdcxx 15.2.0 h934c35e_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 27575
-  timestamp: 1771378314494
 - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
   sha256: b30c06f60f03c2cf101afeb3452f48f12a2553b4cb631c9460c8a8ccf0813ae5
   md5: b04e0a2163a72588a40cde1afd6f2d18
@@ -8593,17 +7496,6 @@ packages:
   purls: []
   size: 491268
   timestamp: 1765552759709
-- conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
-  sha256: c5008b602cb5c819f7b52d418b3ed17e1818cbbf6705b189e7ab36bb70cce3d8
-  md5: 8ee3cb7f64be0e8c4787f3a4dbe024e6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 492799
-  timestamp: 1773797095649
 - conda: https://prefix.dev/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
   sha256: 50c8cd416ac8425e415264de167b41ae8442de22a91098dfdd993ddbf9f13067
   md5: 553281a034e9cf8693c9df49f6c78ea1
@@ -8762,28 +7654,6 @@ packages:
   purls: []
   size: 145023
   timestamp: 1765552781358
-- conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
-  sha256: 1a1e367c04d66030aa93b4d33905f7f6fbb59cfc292e816fe3e9c1e8b3f4d1e2
-  md5: 2c2270f93d6f9073cbf72d821dfc7d72
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 145087
-  timestamp: 1773797108513
-- conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
-  sha256: f2ac872920833960e514ce9efd8f7c08ce66dd870738d73839d1bce1ac497de6
-  md5: a730b2badd586580c5752cc73842e068
-  depends:
-  - libgcc-ng >=9.4.0
-  - libstdcxx-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 75491
-  timestamp: 1638450786937
 - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
   sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
   md5: e179a69edd30d75c0144d7a380b88f28
@@ -8808,18 +7678,6 @@ packages:
   purls: []
   size: 127967
   timestamp: 1756125594973
-- conda: https://prefix.dev/conda-forge/linux-64/liburing-2.9-h84d6215_0.conda
-  sha256: bfa34a5a929d792dfcfbbe2d9ee21bd870d73d646512e21c871dab0b80194468
-  md5: ecd409e7bfcf4ee73f74d7a2cc91a4c3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 121336
-  timestamp: 1738604403935
 - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
   sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
   md5: d17e3fb595a9f24fa9e149239a33475d
@@ -8864,17 +7722,6 @@ packages:
   purls: []
   size: 40311
   timestamp: 1766271528534
-- conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
-  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
-  md5: 38ffe67b78c9d4de527be8315e5ada2c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 40297
-  timestamp: 1775052476770
 - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
   sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
   md5: 0f03292cc56bf91a077a134ea8747118
@@ -9129,18 +7976,6 @@ packages:
   purls: []
   size: 60963
   timestamp: 1727963148474
-- conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
-  md5: d87ff7921124eccd67248aa483c23fec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  constrains:
-  - zlib 1.3.2 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 63629
-  timestamp: 1774072609062
 - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-21.1.7-h4922eb0_0.conda
   sha256: 6579325669ba27344be66f319c316396f09d9f1a054178df257009591b7d7f43
   md5: ec29f865968a81e1961b3c2f2765eebb
@@ -9167,19 +8002,6 @@ packages:
   purls: []
   size: 6127279
   timestamp: 1765964409311
-- conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.4-h4922eb0_0.conda
-  sha256: 40e841ae0a03dfb5eaab6479ba0745b3666c869f5a8d066d42a21615933eeb15
-  md5: fa2c5c7f8d5319ab9c9fcbbd04022abf
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  constrains:
-  - intel-openmp <0.0a0
-  - openmp 22.1.4|22.1.4.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  purls: []
-  size: 6118643
-  timestamp: 1776845714373
 - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393
@@ -9224,22 +8046,6 @@ packages:
   - pkg:pypi/markupsafe?source=hash-mapping
   size: 25321
   timestamp: 1759055268795
-- conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
-  sha256: 5f3aad1f3a685ed0b591faad335957dbdb1b73abfd6fc731a0d42718e0653b33
-  md5: 93a4752d42b12943a355b682ee43285b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/markupsafe?source=hash-mapping
-  size: 26057
-  timestamp: 1772445297924
 - conda: https://prefix.dev/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
   sha256: 1e59d0dc811f150d39c2ff2da930d69dcb91cb05966b7df5b7d85133006668ed
   md5: e4ab075598123e783b788b995afbdad0
@@ -9266,19 +8072,6 @@ packages:
   purls: []
   size: 116777
   timestamp: 1725629179524
-- conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
-  sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
-  md5: 770d00bf57b5599c4544d61b61d8c6c6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gmp >=6.3.0,<7.0a0
-  - libgcc >=14
-  - mpfr >=4.2.2,<5.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 100245
-  timestamp: 1774472435333
 - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
   sha256: f25d2474dd557ca66c6231c8f5ace5af312efde1ba8290a6ea5e1732a4e669c0
   md5: 2eeb50cab6652538eee8fc0bc3340c81
@@ -9291,18 +8084,6 @@ packages:
   purls: []
   size: 634751
   timestamp: 1725746740014
-- conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-  sha256: 8690f550a780f75d9c47f7ffc15f5ff1c149d36ac17208e50eda101ca16611b9
-  md5: 85ce2ffa51ab21da5efa4a9edc5946aa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gmp >=6.3.0,<7.0a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  size: 730422
-  timestamp: 1773413915171
 - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
@@ -9372,19 +8153,6 @@ packages:
   - pkg:pypi/multiprocess?source=hash-mapping
   size: 340540
   timestamp: 1724954755987
-- conda: https://prefix.dev/conda-forge/linux-64/mysql-common-9.0.1-h266115a_6.conda
-  sha256: 9c2e3f9e9883e4b8d7e9e6abf7b235dc00bdcd5ef66640a360464a9f5756294d
-  md5: 94116b69829e90b72d566e64421e1bff
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - openssl >=3.4.1,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 616215
-  timestamp: 1744124836761
 - conda: https://prefix.dev/conda-forge/linux-64/mysql-common-9.3.0-h266115a_0.conda
   sha256: 09008f1b5b8af97e56e1613af09bd6c3cc4fe0c5c3d23f382bf4dc58f5e09163
   md5: 9693774d2822c39a9541f2a80c346e30
@@ -9398,22 +8166,6 @@ packages:
   purls: []
   size: 635956
   timestamp: 1745255372098
-- conda: https://prefix.dev/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_6.conda
-  sha256: 274467a602944d12722f757f660ad034de6f5f5d7d2ea1b913ef6fd836c1b8ce
-  md5: 9802ae6d20982f42c0f5d69008988763
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-common 9.0.1 h266115a_6
-  - openssl >=3.4.1,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 1369369
-  timestamp: 1744124916632
 - conda: https://prefix.dev/conda-forge/linux-64/mysql-libs-9.3.0-he0572af_0.conda
   sha256: 3367465235edea7c78ea0d4e7155171b03bf05f2a7c25cdecf62821de604810e
   md5: 5eb3dd8ccc96213c0961a2bba1f611d1
@@ -9453,16 +8205,6 @@ packages:
   purls: []
   size: 891641
   timestamp: 1738195959188
-- conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
-  md5: fc21868a1a5aacc937e7a18747acb8a5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 918956
-  timestamp: 1777422145199
 - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
   sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
   md5: 16c2a0e9c4a166e53632cfca4f68d020
@@ -9533,26 +8275,6 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 8757015
   timestamp: 1768085678045
-- conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
-  sha256: 1aab7ba963affa572956b1bd8d239df52a9c7bc799c560f98bc658ab70224e10
-  md5: 5930ee8a175a242b4f001b1e9e72024f
-  depends:
-  - python
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - liblapack >=3.9.0,<4.0a0
-  - libblas >=3.9.0,<4.0a0
-  - python_abi 3.12.* *_cp312
-  - libcblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy?source=hash-mapping
-  size: 8757569
-  timestamp: 1773839284329
 - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
   sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
   md5: 56f8947aa9d5cf37b0b3d43b83f34192
@@ -9619,18 +8341,6 @@ packages:
   purls: []
   size: 55357
   timestamp: 1749853464518
-- conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-  sha256: 8de2f0cd8a659b01abf86e7fbb8cea4f28ada62fd288429a2bbc040db1b98dd0
-  md5: c930c8052d780caa41216af7de472226
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 55754
-  timestamp: 1773844383536
 - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.3.5-h09fa569_0.conda
   sha256: db6bac8013542227eda2153b7473b10faef11fd2bae57591d1f729993109e152
   md5: f46ae82586acba0872546bd79261fafc
@@ -9733,18 +8443,6 @@ packages:
   purls: []
   size: 3165399
   timestamp: 1762839186699
-- conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
-  md5: da1b85b6a87e141f5140bb9924cecab0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3167099
-  timestamp: 1775587756857
 - conda: https://prefix.dev/conda-forge/linux-64/optree-0.18.0-py312hd9148b4_0.conda
   sha256: f34a33825d0e925c6b0e09c81632657935e2c0cc595d2a70d9902c7b9f891a51
   md5: 4d4148297810361256ebf85b17693dff
@@ -9761,22 +8459,6 @@ packages:
   - pkg:pypi/optree?source=hash-mapping
   size: 444884
   timestamp: 1763124490090
-- conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda
-  sha256: ff6a3f9124d112541f2557e8b40c00dbca9aaf5e254cd16fb485e8ad925c48d6
-  md5: 5a9273e06750ca36e478c142813e59a8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing-extensions >=4.6
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/optree?source=compressed-mapping
-  size: 492574
-  timestamp: 1778047684091
 - conda: https://prefix.dev/conda-forge/linux-64/orc-2.1.2-h17f744e_0.conda
   sha256: f6ff644e27f42f2beb877773ba3adc1228dbb43530dbe9426dd672f3b847c7c5
   md5: ef7f9897a244b2023a066c22a1089ce4
@@ -9847,83 +8529,6 @@ packages:
   - pkg:pypi/pandas?source=compressed-mapping
   size: 15099922
   timestamp: 1759266031115
-- conda: https://prefix.dev/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
-  sha256: 4aad0f99a06e799acdd46af0df8f7c8273164cabce8b5c94a44b012b7d1a30a6
-  md5: 42050f82a0c0f6fa23eda3d93b251c18
-  depends:
-  - python
-  - numpy >=1.26.0
-  - python-dateutil >=2.8.2
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  constrains:
-  - adbc-driver-postgresql >=1.2.0
-  - adbc-driver-sqlite >=1.2.0
-  - beautifulsoup4 >=4.12.3
-  - blosc >=1.21.3
-  - bottleneck >=1.4.2
-  - fastparquet >=2024.11.0
-  - fsspec >=2024.10.0
-  - gcsfs >=2024.10.0
-  - html5lib >=1.1
-  - hypothesis >=6.116.0
-  - jinja2 >=3.1.5
-  - lxml >=5.3.0
-  - matplotlib >=3.9.3
-  - numba >=0.60.0
-  - numexpr >=2.10.2
-  - odfpy >=1.4.1
-  - openpyxl >=3.1.5
-  - psycopg2 >=2.9.10
-  - pyarrow >=13.0.0
-  - pyiceberg >=0.8.1
-  - pymysql >=1.1.1
-  - pyqt5 >=5.15.9
-  - pyreadstat >=1.2.8
-  - pytables >=3.10.1
-  - pytest >=8.3.4
-  - pytest-xdist >=3.6.1
-  - python-calamine >=0.3.0
-  - pytz >=2024.2
-  - pyxlsb >=1.0.10
-  - qtpy >=2.4.2
-  - scipy >=1.14.1
-  - s3fs >=2024.10.0
-  - sqlalchemy >=2.0.36
-  - tabulate >=0.9.0
-  - xarray >=2024.10.0
-  - xlrd >=2.0.1
-  - xlsxwriter >=3.2.0
-  - zstandard >=0.23.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pandas?source=hash-mapping
-  size: 14849233
-  timestamp: 1774916580467
-- conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.3-h9ac818e_1.conda
-  sha256: 9c00bbc8871b9ce00d1a1f0c1a64f76c032cf16a56a28984b9bb59e46af3932d
-  md5: 21899b96828014270bd24fd266096612
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.13.3,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=11.0.0,<12.0a0
-  - libexpat >=2.6.4,<3.0a0
-  - libgcc >=13
-  - libglib >=2.84.0,<3.0a0
-  - libpng >=1.6.47,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 453100
-  timestamp: 1743352484196
 - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
   sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
   md5: 79f71230c069a287efe3a8614069ddf1
@@ -9945,19 +8550,6 @@ packages:
   purls: []
   size: 455420
   timestamp: 1751292466873
-- conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.44-hc749103_2.conda
-  sha256: 09717569649d89caafbf32f6cda1e65aef86e5a86c053d30e4ce77fca8d27b68
-  md5: 31614c73d7b103ef76faa4d83d261d34
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 956207
-  timestamp: 1745931215744
 - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
   sha256: 27c4014f616326240dcce17b5f3baca3953b6bc5f245ceb49c3fa1e6320571eb
   md5: b90bece58b4c2bf25969b70f3be42d25
@@ -10053,29 +8645,6 @@ packages:
   - pkg:pypi/pillow?source=hash-mapping
   size: 1029473
   timestamp: 1767353193448
-- conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
-  sha256: fa291f8915114733dc1df9f1627b8c63c517217c1eee1a6ede2ceb5e368cf27a
-  md5: 9e5609720e31213d4f39afe377f6217e
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - lcms2 >=2.18,<3.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - python_abi 3.12.* *_cp312
-  - tk >=8.6.13,<8.7.0a0
-  - libfreetype >=2.14.3
-  - libfreetype6 >=2.14.3
-  - zlib-ng >=2.3.3,<2.4.0a0
-  license: HPND
-  purls:
-  - pkg:pypi/pillow?source=compressed-mapping
-  size: 1039561
-  timestamp: 1775060059882
 - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
   md5: c01af13bdc553d1a8fbfff6e8db075f0
@@ -10164,20 +8733,6 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 222353
   timestamp: 1767012395507
-- conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
-  sha256: d834fd656133c9e4eaf63ffe9a117c7d0917d86d89f7d64073f4e3a0020bd8a7
-  md5: dd94c506b119130aef5a9382aed648e7
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil?source=compressed-mapping
-  size: 225545
-  timestamp: 1769678155334
 - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -10239,21 +8794,6 @@ packages:
   purls: []
   size: 764231
   timestamp: 1742507189208
-- conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.11.0-qt6_py312h0412312_604.conda
-  sha256: 161384d6477f643385dbe811c65633d7ee1da552e8a204f38262e9f03b126d61
-  md5: f8b9abc6ccbff53af9cdc2d77b883eeb
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libopencv 4.11.0 qt6_py312ha9b1755_604
-  - libprotobuf >=5.29.3,<5.29.4.0a0
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 1155663
-  timestamp: 1743561901721
 - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.11.0-qt6_py312h0412312_605.conda
   sha256: 148d4dce1cb3324744fe991b7368867adc025320e928c322ece6f5c33ef9ab73
   md5: 60d49894668902b15e7e92292a51336b
@@ -10442,33 +8982,6 @@ packages:
   purls: []
   size: 32123473
   timestamp: 1696324522323
-- conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
-  sha256: a44655c1c3e1d43ed8704890a91e12afd68130414ea2c0872e154e5633a13d7e
-  md5: 7eccb41177e15cc672e1babe9056018e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - liblzma >=5.8.2,<6.0a0
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libuuid >=2.41.3,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.5,<4.0a0
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 31608571
-  timestamp: 1772730708989
 - conda: https://prefix.dev/conda-forge/linux-64/python-xxhash-3.6.0-py312h0d868a3_1.conda
   sha256: c21a54fc11f87b456eee8f525060b60d3bea2b942a85fa1b06241271a80ed7a8
   md5: 1cfb9b04c827219597def32c22fb9ca2
@@ -10623,39 +9136,6 @@ packages:
   - pkg:pypi/pyyaml?source=compressed-mapping
   size: 204539
   timestamp: 1758892248166
-- conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
-  sha256: cb142bfd92f6e55749365ddc244294fa7b64db6d08c45b018ff1c658907bfcbf
-  md5: 15878599a87992e44c059731771591cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 198293
-  timestamp: 1770223620706
-- conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
-  noarch: python
-  sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
-  md5: 082985717303dab433c976986c674b35
-  depends:
-  - python
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - zeromq >=4.3.5,<4.4.0a0
-  - _python_abi3_support 1.*
-  - cpython >=3.12
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pyzmq?source=compressed-mapping
-  size: 211567
-  timestamp: 1771716961404
 - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
   noarch: python
   sha256: a00a41b66c12d9c60e66b391e9a4832b7e28743348cf4b48b410b91927cd7819
@@ -10685,68 +9165,6 @@ packages:
   purls: []
   size: 552937
   timestamp: 1720813982144
-- conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.8.3-h6441bc3_1.conda
-  sha256: 8ae89546e5110af9ba37402313e4799369abedf51f08c833f304dae540ff0566
-  md5: db96ef4241de437be7b41082045ef7d2
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.13,<1.3.0a0
-  - dbus >=1.13.6,<2.0a0
-  - double-conversion >=3.3.1,<3.4.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.13.3,<3.0a0
-  - harfbuzz >=11.0.0,<12.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp20.1 >=20.1.1,<20.2.0a0
-  - libclang13 >=20.1.1
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.124,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.84.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libllvm20 >=20.1.1,<20.2.0a0
-  - libpng >=1.6.47,<1.7.0a0
-  - libpq >=17.4,<18.0a0
-  - libsqlite >=3.49.1,<4.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.5.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.8.1,<2.0a0
-  - libxml2 >=2.13.7,<2.14.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-libs >=9.0.1,<9.1.0a0
-  - openssl >=3.4.1,<4.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  - wayland >=1.23.1,<2.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xcb-util-cursor >=0.1.5,<0.2.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.1,<0.5.0a0
-  - xcb-util-renderutil >=0.3.10,<0.4.0a0
-  - xcb-util-wm >=0.4.2,<0.5.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxcomposite >=0.4.6,<1.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrandr >=1.5.4,<2.0a0
-  - xorg-libxtst >=1.2.5,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - qt 6.8.3
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  size: 50854227
-  timestamp: 1743393321721
 - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.8.3-h75f3359_4.conda
   sha256: e3136c8959fb4323525ffa3dc1178bc4023dae11e76b79a24a253c8a1d74eb9d
   md5: a112bbcd817da41b3db983a7f2d78fd7
@@ -11025,21 +9443,6 @@ packages:
   - pkg:pypi/scipy?source=compressed-mapping
   size: 17109648
   timestamp: 1771880675810
-- conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.54-h3f2d84a_0.conda
-  sha256: 7cd82ca1d1989de6ac28e72ba0bfaae1c055278f931b0c7ef51bb1abba3ddd2f
-  md5: 91f8537d64c4d52cbbb2910e8bd61bd2
-  depends:
-  - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=13
-  - libgcc >=13
-  - sdl3 >=3.2.10,<4.0a0
-  - libgl >=1.7.0,<2.0a0
-  - libegl >=1.7.0,<2.0a0
-  license: Zlib
-  purls: []
-  size: 587053
-  timestamp: 1745799881584
 - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
   sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
   md5: cdd138897d94dc07d99afe7113a07bec
@@ -11054,34 +9457,6 @@ packages:
   purls: []
   size: 589145
   timestamp: 1757842881000
-- conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.2.14-he3e324a_0.conda
-  sha256: b55edbcbcbfc7cff671ef15b6a663b91cb2ca59ab285c283d02f29c51de59e9e
-  md5: a750ab1e94750185033ea96eadfc925d
-  depends:
-  - libstdcxx >=13
-  - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libgl >=1.7.0,<2.0a0
-  - dbus >=1.13.6,<2.0a0
-  - libxkbcommon >=1.9.2,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - libudev1 >=257.4
-  - libunwind >=1.6.2,<1.7.0a0
-  - wayland >=1.23.1,<2.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - libusb >=1.0.28,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  - libdrm >=2.4.124,<2.5.0a0
-  - xorg-libxscrnsaver >=1.2.4,<2.0a0
-  - liburing >=2.9,<2.10.0a0
-  - libegl >=1.7.0,<2.0a0
-  license: Zlib
-  purls: []
-  size: 1939690
-  timestamp: 1747327532502
 - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
   sha256: 47156cd71d4e235f7ce6731f1f6bcf4ee1ff65c3c20b126ac66c86231d0d3d57
   md5: eeb4cfa6070a7882ad50936c7ade65ec
@@ -11220,20 +9595,6 @@ packages:
   purls: []
   size: 183835
   timestamp: 1768147980363
-- conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
-  sha256: d167fa92781bcdcd3b9aaa6bb1cd50c5b108f6190c170098a118b5cf5df2f881
-  md5: 8e0b8654ead18e50af552e54b5a08a61
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libsqlite 3.53.1 h0c1763c_0
-  - libzlib >=1.3.2,<2.0a0
-  - ncurses >=6.6,<7.0a0
-  - readline >=8.3,<9.0a0
-  license: blessing
-  purls: []
-  size: 205399
-  timestamp: 1777986477546
 - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-3.0.2-h5888daf_0.conda
   sha256: fb4b97a3fd259eff4849b2cfe5678ced0c5792b697eb1f7bcd93a4230e90e80e
   md5: 0096882bd623e6cc09e8bf920fc8fb47
@@ -11284,18 +9645,6 @@ packages:
   purls: []
   size: 181262
   timestamp: 1762509955687
-- conda: https://prefix.dev/conda-forge/linux-64/tinyobjloader-1.0.7-h54a6638_3.conda
-  sha256: a119eb5d14922060381a0c15996e1dbf86310cee10d2cce1a82db9c50eb97ca7
-  md5: badf9075c031b69fed7d27532f51c7bc
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 78558
-  timestamp: 1773509682293
 - conda: https://prefix.dev/conda-forge/linux-64/tinyobjloader-1.0.7-h59595ed_2.conda
   sha256: 72628067e594f1431968143aed6a5d4e6f0f5d6d1aac0c5165b04143b4f03119
   md5: 3d75225b64bcbdc86128e693104a409d
@@ -11307,20 +9656,6 @@ packages:
   purls: []
   size: 71746
   timestamp: 1704450371417
-- conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
-  md5: cffd3bdd58090148f4cfcd831f4b26ab
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3301196
-  timestamp: 1769460227866
 - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
   sha256: 1544760538a40bcd8ace2b1d8ebe3eb5807ac268641f8acdc18c69c5ebfeaf64
   md5: 86bc20552bf46075e3d92b67f089172d
@@ -11484,20 +9819,6 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 850918
   timestamp: 1765458857375
-- conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.5-py312h4c3975b_0.conda
-  sha256: 4629b1c9139858fb08bb357df917ffc12e4d284c57ff389806bb3ae476ef4e0a
-  md5: 2b37798adbc54fd9e591d24679d2133a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/tornado?source=compressed-mapping
-  size: 859665
-  timestamp: 1774358032165
 - conda: https://prefix.dev/conda-forge/linux-64/triton-3.3.1-cuda129py312h811769c_2.conda
   sha256: 1c2b12f36ab3c3ac4255e5029982075ddf5f254c24464096b4d5d7f43f372ef2
   md5: 467e5c72b0f89e790ef211315c13effd
@@ -11609,20 +9930,6 @@ packages:
   purls: []
   size: 330474
   timestamp: 1751817998141
-- conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-  sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
-  md5: 996583ea9c796e5b915f7d7580b51ea6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 334139
-  timestamp: 1773959575393
 - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
   md5: 6c99772d483f566d59e25037fea2c4b1
@@ -11728,18 +10035,6 @@ packages:
   purls: []
   size: 396975
   timestamp: 1759543819846
-- conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
-  sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
-  md5: b56e0c8432b56decafae7e78c5f29ba5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 399291
-  timestamp: 1772021302485
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -11776,18 +10071,6 @@ packages:
   purls: []
   size: 835896
   timestamp: 1741901112627
-- conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
-  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libxcb >=1.17.0,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 839652
-  timestamp: 1770819209719
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
   sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
   md5: b2895afaf55bf96a8c8282a2e47a5de0
@@ -11876,18 +10159,6 @@ packages:
   purls: []
   size: 50060
   timestamp: 1727752228921
-- conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
-  md5: 34e54f03dfea3e7a2dcf1453a85f1085
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 50326
-  timestamp: 1769445253162
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
   sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
   md5: ba231da7fccf9ea1e768caf5c7099b84
@@ -11956,20 +10227,6 @@ packages:
   purls: []
   size: 29599
   timestamp: 1727794874300
-- conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
-  md5: e192019153591938acf7322b6459d36e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 30456
-  timestamp: 1769445263457
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   md5: 96d57aba173e878a2089d5638016dc5e
@@ -12172,17 +10429,6 @@ packages:
   purls: []
   size: 92286
   timestamp: 1727963153079
-- conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
-  sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
-  md5: c2a01a08fc991620a74b32420e97868a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libzlib 1.3.2 h25fd6f3_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 95931
-  timestamp: 1774072620848
 - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.2-h54a6638_0.conda
   sha256: 0afb07f3511031c35202036e2cd819c90edaa0c6a39a7a865146d3cb066bec96
   md5: 0faadd01896315ceea58bcc3479b1d21
@@ -12206,18 +10452,6 @@ packages:
   purls: []
   size: 122303
   timestamp: 1766076745735
-- conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-  sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
-  md5: 2aadb0d17215603a82a2a6b0afd9a4cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 122618
-  timestamp: 1770167931827
 - conda: https://prefix.dev/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
   sha256: c2bcb8aa930d6ea3c9c7a64fc4fab58ad7bcac483a9a45de294f67d2f447f413
   md5: 02738ff9855946075cbd1b5274399a41
@@ -12317,25 +10551,6 @@ packages:
   - pkg:pypi/anyio?source=compressed-mapping
   size: 145175
   timestamp: 1767719033569
-- conda: https://prefix.dev/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-  sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
-  md5: af2df4b9108808da3dc76710fe50eae2
-  depends:
-  - exceptiongroup >=1.0.2
-  - idna >=2.8
-  - python >=3.10
-  - typing_extensions >=4.5
-  - python
-  constrains:
-  - trio >=0.32.0
-  - uvloop >=0.22.1
-  - winloop >=0.2.3
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/anyio?source=hash-mapping
-  size: 146764
-  timestamp: 1774359453364
 - conda: https://prefix.dev/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
   sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
   md5: 54898d0f524c9dee622d44bbb081a8ab
@@ -12415,19 +10630,6 @@ packages:
   - pkg:pypi/async-lru?source=compressed-mapping
   size: 21470
   timestamp: 1771623881915
-- conda: https://prefix.dev/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
-  sha256: ea8486637cfb89dc26dc9559921640cd1d5fd37e5e02c33d85c94572139f2efe
-  md5: b85e84cb64c762569cc1a760c2327e0a
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.0.0
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/async-lru?source=compressed-mapping
-  size: 22949
-  timestamp: 1773926359134
 - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
   sha256: c13d5e42d187b1d0255f591b7ce91201d4ed8a5370f0d986707a802c20c9d32f
   md5: 537296d57ea995666c68c821b00e360b
@@ -12440,18 +10642,6 @@ packages:
   - pkg:pypi/attrs?source=compressed-mapping
   size: 64759
   timestamp: 1764875182184
-- conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-  sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
-  md5: c6b0543676ecb1fb2d7643941fe375f2
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/attrs?source=compressed-mapping
-  size: 64927
-  timestamp: 1773935801332
 - conda: https://prefix.dev/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
   sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
   md5: 0a01c169f0ab0f91b26e77a3301fbfe4
@@ -12477,20 +10667,6 @@ packages:
   - pkg:pypi/babel?source=compressed-mapping
   size: 7684373
   timestamp: 1770326844118
-- conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
-  sha256: a14a9ad02101aab25570543a59c5193043b73dc311a25650134ed9e6cb691770
-  md5: f1976ce927373500cc19d3c0b2c85177
-  depends:
-  - python >=3.10
-  - python
-  constrains:
-  - pytz >=2015.7
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/babel?source=compressed-mapping
-  size: 7684321
-  timestamp: 1772555330347
 - conda: https://prefix.dev/conda-forge/noarch/beartype-0.21.0-pyhd8ed1ab_0.conda
   sha256: 0903a3f2e57c422f9ad8d1e182c5eef5278c5c962f41a8f938d0f68effca329c
   md5: 526bf12efa59226d9f76cd6742debc41
@@ -12623,15 +10799,6 @@ packages:
   purls: []
   size: 147413
   timestamp: 1772006283803
-- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
-  sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
-  md5: e18ad67cf881dcadee8b8d9e2f8e5f73
-  depends:
-  - __unix
-  license: ISC
-  purls: []
-  size: 131039
-  timestamp: 1776865545798
 - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
   noarch: python
   sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
@@ -12695,16 +10862,6 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 151445
   timestamp: 1772001170301
-- conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
-  sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
-  md5: 929471569c93acefb30282a22060dcd5
-  depends:
-  - python >=3.10
-  license: ISC
-  purls:
-  - pkg:pypi/certifi?source=compressed-mapping
-  size: 135656
-  timestamp: 1776866680878
 - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
   sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
   md5: a22d1fd9bf98827e280a02875d9a007a
@@ -12716,17 +10873,6 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 50965
   timestamp: 1760437331772
-- conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
-  sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
-  md5: a9167b9571f3baa9d448faa2139d1089
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/charset-normalizer?source=hash-mapping
-  size: 58872
-  timestamp: 1775127203018
 - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
   sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
   md5: ea8a6c3256897cc31263de9f455e25d9
@@ -12740,19 +10886,6 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 97676
   timestamp: 1764518652276
-- conda: https://prefix.dev/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
-  sha256: 37a5d8b10ea3516e2c42f870c9c351b9f7b31ff48c66d83490039f417e1e5228
-  md5: 2266262ce8a425ecb6523d765f79b303
-  depends:
-  - __unix
-  - python
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/click?source=compressed-mapping
-  size: 100048
-  timestamp: 1777219902525
 - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -12798,17 +10931,6 @@ packages:
   purls: []
   size: 46644
   timestamp: 1769471040321
-- conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-  noarch: generic
-  sha256: d3e9bbd7340199527f28bbacf947702368f31de60c433a16446767d3c6aaf6fe
-  md5: f54c1ffb8ecedb85a8b7fcde3a187212
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi * *_cp312
-  license: Python-2.0
-  purls: []
-  size: 46463
-  timestamp: 1772728929620
 - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
   sha256: 2ee3b9564ca326226e5cda41d11b251482df8e7c757e333d28ec75213c75d126
   md5: 87ff6381e33b76e5b9b179a2cdd005ec
@@ -12963,30 +11085,6 @@ packages:
   - pkg:pypi/dash?source=hash-mapping
   size: 5235402
   timestamp: 1770220645911
-- conda: https://prefix.dev/conda-forge/noarch/dash-4.1.0-pyhd8ed1ab_0.conda
-  sha256: da728f7cd366929e1cde8e7168c3f2518594a46835ce18d71b283e55d38d8dfe
-  md5: bbdfd2c9735e0367e10e941875bdf9d0
-  depends:
-  - flask >=1.0.4
-  - importlib-metadata
-  - nest-asyncio
-  - plotly >=5.0.0
-  - python >=3.10
-  - requests
-  - retrying
-  - setuptools
-  - typing_extensions >=4.1.1
-  - werkzeug
-  constrains:
-  - dash_table >=5.0.0
-  - dash-html-components >=2.0.0
-  - dash-core-components >=2.0.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/dash?source=hash-mapping
-  size: 5325663
-  timestamp: 1774336225580
 - conda: https://prefix.dev/conda-forge/noarch/datasets-4.0.0-pyhcf101f3_0.conda
   sha256: 12f4fded6326b22a08f0c82a1d9a9e5fe30a70e48c47a83a1ef4cd9aefd7ffac
   md5: cd5b76468a51357e189e19809e62dc15
@@ -13144,16 +11242,6 @@ packages:
   - pkg:pypi/filelock?source=compressed-mapping
   size: 25656
   timestamp: 1772380968183
-- conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
-  sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
-  md5: 8fa8358d022a3a9bd101384a808044c6
-  depends:
-  - python >=3.10
-  license: Unlicense
-  purls:
-  - pkg:pypi/filelock?source=compressed-mapping
-  size: 34211
-  timestamp: 1776621506566
 - conda: https://prefix.dev/conda-forge/noarch/flask-3.1.2-pyhd8ed1ab_0.conda
   sha256: 8a97eba37e0723720706d4636cc89c6b07eea1b7cc66fd8994fa8983a81ed988
   md5: ba67a9febeda36948fee26a3dec3d914
@@ -13396,22 +11484,6 @@ packages:
   - pkg:pypi/hypothesis?source=hash-mapping
   size: 382777
   timestamp: 1764903748476
-- conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.152.4-pyha770c72_0.conda
-  sha256: 4803b0adba33fba7c393fa48556fe203b65d420557b7cd57ed0f9ace402d5e54
-  md5: 905684b2d1121c57da0a163455c7805b
-  depends:
-  - attrs >=22.2.0
-  - click >=7.0
-  - exceptiongroup >=1.0.0
-  - python >=3.10
-  - setuptools
-  - sortedcontainers >=2.1.0,<3.0.0
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls:
-  - pkg:pypi/hypothesis?source=compressed-mapping
-  size: 379522
-  timestamp: 1777332575730
 - conda: https://prefix.dev/conda-forge/noarch/icecream-2.1.10-pyhd8ed1ab_0.conda
   sha256: fc98472faeb6303928a51293120f0a10ce54a83f02a98c9d7d13ba664f0c2edf
   md5: 8f13926864eefc16b0bbe2a51652507e
@@ -13442,21 +11514,6 @@ packages:
   - pkg:pypi/icecream?source=hash-mapping
   size: 15360
   timestamp: 1757869434890
-- conda: https://prefix.dev/conda-forge/noarch/icecream-2.2.0-pyhd8ed1ab_0.conda
-  sha256: eb943bfce15d354c9065a794e63fe2ab193bf4890b661486b71ff8dd81e619ea
-  md5: 9d1593318a74fc517d9bbfe27ca55239
-  depends:
-  - asttokens >=2.0.1
-  - colorama >=0.3.9
-  - executing >=0.3.1
-  - pygments >=2.2.0
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/icecream?source=hash-mapping
-  size: 16644
-  timestamp: 1775311285561
 - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
   sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
   md5: 53abe63df7e10a6ba605dc5f9f961d36
@@ -13468,18 +11525,6 @@ packages:
   - pkg:pypi/idna?source=hash-mapping
   size: 50721
   timestamp: 1760286526795
-- conda: https://prefix.dev/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
-  sha256: 9ab620e6f64bb67737bd7bc1ad6f480770124e304c6710617aba7fe60b089f48
-  md5: fb7130c190f9b4ec91219840a05ba3ac
-  depends:
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/idna?source=compressed-mapping
-  size: 59038
-  timestamp: 1776947141407
 - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
   sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
   md5: 63ccfdc3a3ce25b027b8767eb722fca8
@@ -13493,19 +11538,6 @@ packages:
   - pkg:pypi/importlib-metadata?source=hash-mapping
   size: 34641
   timestamp: 1747934053147
-- conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
-  sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
-  md5: 080594bf4493e6bae2607e65390c520a
-  depends:
-  - python >=3.10
-  - zipp >=3.20
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/importlib-metadata?source=compressed-mapping
-  size: 34387
-  timestamp: 1773931568510
 - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
   md5: 9614359868482abba1bd15ce465e3c42
@@ -13573,33 +11605,6 @@ packages:
   - pkg:pypi/ipykernel?source=compressed-mapping
   size: 132260
   timestamp: 1770566135697
-- conda: https://prefix.dev/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
-  sha256: b77ed58eb235e5ad80e742b03caeed4bbc2a2ef064cb9a2deee3b75dfae91b2a
-  md5: 8b267f517b81c13594ed68d646fd5dcb
-  depends:
-  - __linux
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=8.8.0
-  - jupyter_core >=5.1,!=6.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio >=1.4
-  - packaging >=22
-  - psutil >=5.7
-  - python >=3.10
-  - pyzmq >=25
-  - tornado >=6.4.1
-  - traitlets >=5.4.0
-  - python
-  constrains:
-  - appnope >=0.1.2
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/ipykernel?source=hash-mapping
-  size: 133644
-  timestamp: 1770566133040
 - conda: https://prefix.dev/conda-forge/noarch/ipython-9.10.0-pyh53cf698_0.conda
   sha256: 12cb4db242ea1a2e5e60a51b20f16e9c8120a9eb5d013c641cbf827bf3bb78e1
   md5: 441ca4e203a62f7db2f29f190c02b9cf
@@ -13623,30 +11628,6 @@ packages:
   - pkg:pypi/ipython?source=compressed-mapping
   size: 647436
   timestamp: 1770040907512
-- conda: https://prefix.dev/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
-  sha256: a0af49948a1842dfd15a0b0b2fd56c94ddbd07e07a6c8b4bc70d43015eafaff0
-  md5: 73e9657cd19605740d21efb14d8d0cb9
-  depends:
-  - __unix
-  - decorator >=5.1.0
-  - ipython_pygments_lexers >=1.0.0
-  - jedi >=0.18.2
-  - matplotlib-inline >=0.1.6
-  - prompt-toolkit >=3.0.41,<3.1.0
-  - psutil >=7
-  - pygments >=2.14.0
-  - python >=3.11
-  - stack_data >=0.6.0
-  - traitlets >=5.13.0
-  - typing_extensions >=4.6
-  - pexpect >4.6
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/ipython?source=compressed-mapping
-  size: 651632
-  timestamp: 1777038396606
 - conda: https://prefix.dev/conda-forge/noarch/ipython-9.8.0-pyh53cf698_0.conda
   sha256: 8a72c9945dc4726ee639a9652b622ae6b03f3eba0e16a21d1c6e5bfb562f5a3f
   md5: fd77b1039118a3e8ce1070ac8ed45bae
@@ -13786,17 +11767,6 @@ packages:
   - pkg:pypi/json5?source=hash-mapping
   size: 34017
   timestamp: 1767325114901
-- conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
-  sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
-  md5: 1269891272187518a0a75c286f7d0bbf
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/json5?source=compressed-mapping
-  size: 34731
-  timestamp: 1774655440045
 - conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.0.0-pyhcf101f3_3.conda
   sha256: 1a1328476d14dfa8b84dbacb7f7cd7051c175498406dc513ca6c679dc44f3981
   md5: cd2214824e36b0180141d422aba01938
@@ -13809,18 +11779,6 @@ packages:
   - pkg:pypi/jsonpointer?source=hash-mapping
   size: 13967
   timestamp: 1765026384757
-- conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
-  sha256: a3d10301b6ff399ba1f3d39e443664804a3d28315a4fb81e745b6817845f70ae
-  md5: 89bf346df77603055d3c8fe5811691e6
-  depends:
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/jsonpointer?source=hash-mapping
-  size: 14190
-  timestamp: 1774311356147
 - conda: https://prefix.dev/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
   sha256: ac377ef7762e49cb9c4f985f1281eeff471e9adc3402526eea78e6ac6589cf1d
   md5: 341fd940c242cf33e832c0402face56f
@@ -13918,20 +11876,6 @@ packages:
   - pkg:pypi/jupyter-lsp?source=hash-mapping
   size: 60377
   timestamp: 1756388269267
-- conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
-  sha256: 3766e2ae59641c172cec8a821528bfa6bf9543ffaaeb8b358bfd5259dcf18e4e
-  md5: 0c3b465ceee138b9c39279cc02e5c4a0
-  depends:
-  - importlib-metadata >=4.8.3
-  - jupyter_server >=1.1.2
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/jupyter-lsp?source=compressed-mapping
-  size: 61633
-  timestamp: 1775136333147
 - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.7.0-pyhcf101f3_0.conda
   sha256: 6aa61417547b925de64905b7a4da7c98e0b355f48a7b21bdbef438f8950ee74e
   md5: 1b0397a7b1fbffa031feb690b5fd0277
@@ -14023,26 +11967,6 @@ packages:
   - pkg:pypi/jupyter-events?source=hash-mapping
   size: 24306
   timestamp: 1770937604863
-- conda: https://prefix.dev/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
-  sha256: c7edb5682c6316a95ad781dccb1b6589cd2ec0bf94f23c21152974eb0363b5d7
-  md5: bf42ee94c750c0b2e7e998b79ac299ea
-  depends:
-  - jsonschema-with-format-nongpl >=4.18.0
-  - packaging
-  - python >=3.10
-  - python-json-logger >=2.0.4
-  - pyyaml >=5.3
-  - referencing
-  - rfc3339-validator
-  - rfc3986-validator >=0.1.1
-  - traitlets >=5.3
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/jupyter-events?source=compressed-mapping
-  size: 24002
-  timestamp: 1776861872237
 - conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
   sha256: 74c4e642be97c538dae1895f7052599dfd740d8bd251f727bce6453ce8d6cd9a
   md5: d79a87dcfa726bcea8e61275feed6f83
@@ -14073,36 +11997,6 @@ packages:
   - pkg:pypi/jupyter-server?source=hash-mapping
   size: 347094
   timestamp: 1755870522134
-- conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.18.2-pyhcf101f3_0.conda
-  sha256: 04fb8ea7749f67abaf76df6257bf86688e1389ceed55eb4fb0176fd2e882dbd6
-  md5: 5ee7945accf0f215ddd6055d25d7cd83
-  depends:
-  - anyio >=3.1.0
-  - argon2-cffi >=21.1
-  - jinja2 >=3.0.3
-  - jupyter_client >=7.4.4
-  - jupyter_core >=4.12,!=5.0.*
-  - jupyter_events >=0.11.0
-  - jupyter_server_terminals >=0.4.4
-  - nbconvert-core >=6.4.4
-  - nbformat >=5.3.0
-  - overrides >=5.0
-  - packaging >=22.0
-  - prometheus_client >=0.9
-  - python >=3.10
-  - pyzmq >=24
-  - send2trash >=1.8.2
-  - terminado >=0.8.3
-  - tornado >=6.2.0
-  - traitlets >=5.6.0
-  - websocket-client >=1.7
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/jupyter-server?source=compressed-mapping
-  size: 360522
-  timestamp: 1778060967727
 - conda: https://prefix.dev/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
   sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
   md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
@@ -14203,31 +12097,6 @@ packages:
   - pkg:pypi/jupyterlab?source=compressed-mapping
   size: 7994221
   timestamp: 1771885064306
-- conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.5.7-pyhd8ed1ab_0.conda
-  sha256: b85befad5ba1f50c0cc042a2ffb26441d13ffc2f18572dc20d3541476da0c7b9
-  md5: 2ffe77234070324e763a6eddabb5f467
-  depends:
-  - async-lru >=1.0.0
-  - httpx >=0.25.0,<1
-  - ipykernel >=6.5.0,!=6.30.0
-  - jinja2 >=3.0.3
-  - jupyter-lsp >=2.0.0
-  - jupyter_core
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab_server >=2.28.0,<3
-  - notebook-shim >=0.2
-  - packaging
-  - python >=3.10
-  - setuptools >=41.1.0
-  - tomli >=1.2.2
-  - tornado >=6.2.0
-  - traitlets
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/jupyterlab?source=compressed-mapping
-  size: 8861204
-  timestamp: 1777483115382
 - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
   sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
   md5: fd312693df06da3578383232528c468d
@@ -14333,18 +12202,6 @@ packages:
   - pkg:pypi/markdown-it-py?source=hash-mapping
   size: 64736
   timestamp: 1754951288511
-- conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-  sha256: 0c4c35376fe920714390d46e4b8d31c876d65f18e1655899e0763ec25f2a902f
-  md5: 6d03368f2b2b0a5fb6839df53b2eb5e0
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/markdown-it-py?source=compressed-mapping
-  size: 69017
-  timestamp: 1778169663339
 - conda: https://prefix.dev/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
   sha256: 9d690334de0cd1d22c51bc28420663f4277cfa60d34fa5cad1ce284a13f1d603
   md5: 00e120ce3e40bad7bfc78861ce3c4a25
@@ -14394,19 +12251,6 @@ packages:
   - pkg:pypi/mistune?source=hash-mapping
   size: 74250
   timestamp: 1766504456031
-- conda: https://prefix.dev/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
-  sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
-  md5: b97e84d1553b4a1c765b87fff83453ad
-  depends:
-  - python >=3.10
-  - typing_extensions
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/mistune?source=compressed-mapping
-  size: 74567
-  timestamp: 1777824616382
 - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
   sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
   md5: 3585aa87c43ab15b167b574cd73b057b
@@ -14429,17 +12273,6 @@ packages:
   - pkg:pypi/mpmath?source=compressed-mapping
   size: 464419
   timestamp: 1771870721583
-- conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
-  sha256: 5bbf2f8179ec43d34d67ca8e4989d216c1bdb4b749fe6cb40e86ebf88c1b5300
-  md5: 2e81b32b805f406d23ba61938a184081
-  depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/mpmath?source=compressed-mapping
-  size: 464918
-  timestamp: 1773662068273
 - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -14487,18 +12320,6 @@ packages:
   - pkg:pypi/narwhals?source=compressed-mapping
   size: 280418
   timestamp: 1773164865770
-- conda: https://prefix.dev/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
-  sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
-  md5: 6cac1a50359219d786453c6fef819f98
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/narwhals?source=compressed-mapping
-  size: 283664
-  timestamp: 1776691974709
 - conda: https://prefix.dev/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
   sha256: 594ae12c32f163f6d312e38de41311a89e476544613df0c1d048f699721621d7
   md5: 0aa03903d33997f3886be58abc890aef
@@ -14613,36 +12434,6 @@ packages:
   - pkg:pypi/nbconvert?source=compressed-mapping
   size: 202284
   timestamp: 1769709543555
-- conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
-  sha256: ab2ac79c5892c5434d50b3542d96645bdaa06d025b6e03734be29200de248ac2
-  md5: 2bce0d047658a91b99441390b9b27045
-  depends:
-  - beautifulsoup4
-  - bleach-with-css !=5.0.0
-  - defusedxml
-  - importlib-metadata >=3.6
-  - jinja2 >=3.0
-  - jupyter_core >=4.7
-  - jupyterlab_pygments
-  - markupsafe >=2.0
-  - mistune >=2.0.3,<4
-  - nbclient >=0.5.0
-  - nbformat >=5.7
-  - packaging
-  - pandocfilters >=1.4.1
-  - pygments >=2.4.1
-  - python >=3.10
-  - traitlets >=5.1
-  - python
-  constrains:
-  - pandoc >=2.9.2,<4.0.0
-  - nbconvert ==7.17.1 *_0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/nbconvert?source=compressed-mapping
-  size: 202229
-  timestamp: 1775615493260
 - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
   sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
   md5: bbe1963f1e47f594070ffe87cdf612ea
@@ -14743,18 +12534,6 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
-- conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
-  md5: 4c06a92e74452cfa53623a81592e8934
-  depends:
-  - python >=3.8
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/packaging?source=compressed-mapping
-  size: 91574
-  timestamp: 1777103621679
 - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
   sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   md5: 457c2c8c08e54905d6954e79cb5b5db9
@@ -14790,18 +12569,6 @@ packages:
   - pkg:pypi/parso?source=hash-mapping
   size: 82287
   timestamp: 1770676243987
-- conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
-  sha256: 611882f7944b467281c46644ffde6c5145d1a7730388bcde26e7e86819b0998e
-  md5: 39894c952938276405a1bd30e4ce2caf
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/parso?source=compressed-mapping
-  size: 82472
-  timestamp: 1777722955579
 - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   md5: d0d408b1f18883a944376da5cf8101ea
@@ -14837,18 +12604,6 @@ packages:
   - pkg:pypi/platformdirs?source=compressed-mapping
   size: 25643
   timestamp: 1771233827084
-- conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-  sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
-  md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/platformdirs?source=compressed-mapping
-  size: 25862
-  timestamp: 1775741140609
 - conda: https://prefix.dev/conda-forge/noarch/plotly-6.5.0-pyhd8ed1ab_0.conda
   sha256: 13b06d2380fc46c299d2ae3465f90f156929b7f98597fc22b0e7ac0cfd40c20d
   md5: 6d4c79b604d50c1140c32164f7eca72a
@@ -14931,19 +12686,6 @@ packages:
   - pkg:pypi/plum-dispatch?source=hash-mapping
   size: 40583
   timestamp: 1761664480000
-- conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
-  sha256: cac00838817971ab0de335360435d06848a6307324076c6edadfa0490ddb7f53
-  md5: 77d49f8df60341645e6b81bd990afbc6
-  depends:
-  - beartype >=0.12
-  - python >=3.10
-  - rich >=10.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/plum-dispatch?source=compressed-mapping
-  size: 43387
-  timestamp: 1777376109585
 - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
   sha256: 13dc67de68db151ff909f2c1d2486fa7e2d51355b25cee08d26ede1b62d48d40
   md5: a1e91db2d17fd258c64921cb38e6745a
@@ -14966,17 +12708,6 @@ packages:
   - pkg:pypi/prometheus-client?source=compressed-mapping
   size: 56634
   timestamp: 1768476602855
-- conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
-  sha256: 4d7ec90d4f9c1f3b4a50623fefe4ebba69f651b102b373f7c0e9dbbfa43d495c
-  md5: a11ab1f31af799dd93c3a39881528884
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/prometheus-client?source=hash-mapping
-  size: 57113
-  timestamp: 1775771465170
 - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
   sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
   md5: edb16f14d920fb3faf17f5ce582942d6
@@ -15022,17 +12753,6 @@ packages:
   - pkg:pypi/pyarrow-stubs?source=hash-mapping
   size: 168569
   timestamp: 1765251098840
-- conda: https://prefix.dev/conda-forge/noarch/pyarrow-stubs-20.0.0.20251215-pyhd8ed1ab_0.conda
-  sha256: 1d904aa4d5667b4894e679d91984dc9e9478394779b57200abf3b82b0fb69fbd
-  md5: f14342b99af561bc85512a98982788b7
-  depends:
-  - python >=3.10,<4.0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pyarrow-stubs?source=hash-mapping
-  size: 168546
-  timestamp: 1765786639810
 - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
   sha256: 2558727093f13d4c30e124724566d16badd7de532fd8ee7483628977117d02be
   md5: 70ece62498c769280f791e836ac53fff
@@ -15063,21 +12783,6 @@ packages:
   - pkg:pypi/pybind11?source=compressed-mapping
   size: 245509
   timestamp: 1771365898778
-- conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
-  sha256: 71a9524f44d6ac6304feae71e2bbe8d8ce0816f0be7a0271c15681ad1040965d
-  md5: e0f4549ccb507d4af8ed5c5345210673
-  depends:
-  - python >=3.8
-  - pybind11-global ==3.0.3 *_0
-  - python
-  constrains:
-  - pybind11-abi ==11
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pybind11?source=compressed-mapping
-  size: 247963
-  timestamp: 1775004608640
 - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
   sha256: f11a5903879fe3a24e0d28329cb2b1945127e85a4cdb444b45545cf079f99e2d
   md5: fe10b422ce8b5af5dab3740e4084c3f9
@@ -15108,21 +12813,6 @@ packages:
   - pkg:pypi/pybind11-global?source=compressed-mapping
   size: 241244
   timestamp: 1771365839659
-- conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
-  sha256: 97a0fbd2a81d95e90d714e5c628fe860b29a3caad53abcfb90add1965ad85bef
-  md5: 7fdc3e18c14b862ae5f064c1ea8e2636
-  depends:
-  - python >=3.8
-  - __unix
-  - python
-  constrains:
-  - pybind11-abi ==11
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pybind11-global?source=hash-mapping
-  size: 243898
-  timestamp: 1775004520432
 - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
@@ -15146,17 +12836,6 @@ packages:
   - pkg:pypi/pygments?source=hash-mapping
   size: 889287
   timestamp: 1750615908735
-- conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
-  md5: 16c18772b340887160c79a6acc022db0
-  depends:
-  - python >=3.10
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pygments?source=compressed-mapping
-  size: 893031
-  timestamp: 1774796815820
 - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.20.1-pyhd8ed1ab_0.conda
   sha256: a3af70ef83a4010e71933df3162d7a086c42a5a7fd6d1b6020adecc2730affcf
   md5: c468b661f7fd8a17e7cf302dbed7844e
@@ -15191,24 +12870,6 @@ packages:
   - pkg:pypi/pyserde?source=hash-mapping
   size: 40379
   timestamp: 1736544003563
-- conda: https://prefix.dev/conda-forge/noarch/pyserde-0.29.1-pyhcf101f3_0.conda
-  sha256: 4f2cd940510e1a542096e1bc6daf12ec1c3b7c497a882880f7d96ce17139097d
-  md5: 4629ffe3f10ab1b5903c374b15fc0b86
-  depends:
-  - python >=3.10
-  - typing_inspect >=0.4.0
-  - typing_extensions >=4.1.0,<4.16.0
-  - casefy
-  - jinja2
-  - plum-dispatch >=2.3
-  - beartype >=0.18.4
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyserde?source=hash-mapping
-  size: 45027
-  timestamp: 1769456663144
 - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -15287,16 +12948,6 @@ packages:
   purls: []
   size: 46618
   timestamp: 1769471082980
-- conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
-  sha256: 97327b9509ae3aae28d27217a5d7bd31aff0ab61a02041e9c6f98c11d8a53b29
-  md5: 32780d6794b8056b78602103a04e90ef
-  depends:
-  - cpython 3.12.13.*
-  - python_abi * *_cp312
-  license: Python-2.0
-  purls: []
-  size: 46449
-  timestamp: 1772728979370
 - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
   sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
   md5: a61bf9ec79426938ff785eb69dbb1960
@@ -15308,18 +12959,6 @@ packages:
   - pkg:pypi/python-json-logger?source=hash-mapping
   size: 13383
   timestamp: 1677079727691
-- conda: https://prefix.dev/conda-forge/noarch/python-json-logger-3.2.1-pyh332efcf_0.conda
-  sha256: 1c55116c22512cef7b01d55ae49697707f2c1fd829407183c19817e2d300fd8d
-  md5: 1cd2f3e885162ee1366312bd1b1677fd
-  depends:
-  - python >=3.10
-  - typing_extensions
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/python-json-logger?source=compressed-mapping
-  size: 18969
-  timestamp: 1777318679482
 - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
   sha256: e8392a8044d56ad017c08fec2b0eb10ae3d1235ac967d0aab8bd7b41c4a5eaf0
   md5: 88476ae6ebd24f39261e0854ac244f33
@@ -15342,17 +12981,6 @@ packages:
   - pkg:pypi/tzdata?source=compressed-mapping
   size: 143542
   timestamp: 1765719982349
-- conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
-  sha256: e943f9c15a6bdba2e1b9f423ab913b3f6b02197b0ef9f8e6b7464d78b59965b9
-  md5: f6ad7450fc21e00ecc23812baed6d2e4
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/tzdata?source=compressed-mapping
-  size: 146639
-  timestamp: 1777068997932
 - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   build_number: 8
   sha256: 7ad76fa396e4bde336872350124c0819032a9e8a0a40590744ff9527b54351c1
@@ -15436,24 +13064,6 @@ packages:
   - pkg:pypi/requests?source=hash-mapping
   size: 59263
   timestamp: 1755614348400
-- conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_1.conda
-  sha256: 7f2c24dd3bd3c104a1d2c9a10ead5ed6758b0976b74f972cfe9c19884ccc4241
-  md5: 9659f587a8ceacc21864260acd02fc67
-  depends:
-  - python >=3.10
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - urllib3 >=1.26,<3
-  - python
-  constrains:
-  - chardet >=3.0.2,<8
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/requests?source=compressed-mapping
-  size: 63728
-  timestamp: 1777030058920
 - conda: https://prefix.dev/conda-forge/noarch/retrying-1.4.2-pyhe01879c_0.conda
   sha256: 7a10527962d2ca2cf936872ef58d4b622b1d1d1703e1d6396d0673fd9f883c7f
   md5: 128b46a47ea164f9a8659cb6da2f3555
@@ -15532,21 +13142,6 @@ packages:
   - pkg:pypi/rich?source=compressed-mapping
   size: 208472
   timestamp: 1771572730357
-- conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
-  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
-  md5: 0242025a3c804966bf71aa04eee82f66
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.10
-  - typing_extensions >=4.0.0,<5.0.0
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/rich?source=hash-mapping
-  size: 208577
-  timestamp: 1775991661559
 - conda: https://prefix.dev/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
   sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
   md5: 938c8de6b9de091997145b3bf25cdbf9
@@ -15586,19 +13181,6 @@ packages:
   - pkg:pypi/send2trash?source=hash-mapping
   size: 22519
   timestamp: 1770937603551
-- conda: https://prefix.dev/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
-  sha256: 59656f6b2db07229351dfb3a859c35e57cc8e8bcbc86d4e501bff881a6f771f1
-  md5: 28eb91468df04f655a57bcfbb35fc5c5
-  depends:
-  - __linux
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/send2trash?source=hash-mapping
-  size: 24108
-  timestamp: 1770937597662
 - conda: https://prefix.dev/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
   sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
   md5: 4de79c071274a53dcaf2a8c749d1499e
@@ -15621,17 +13203,6 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 637506
   timestamp: 1770634745653
-- conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
-  md5: 8e194e7b992f99a5015edbd4ebd38efd
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/setuptools?source=hash-mapping
-  size: 639697
-  timestamp: 1773074868565
 - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
   sha256: 02567ec721dd5ff6e8942c1cf1db9bb12df64409ff48fc3571b212c122ef9006
   md5: 3b92b45edc5da4cbd603dd7a059f402a
@@ -15844,18 +13415,6 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 21453
   timestamp: 1768146676791
-- conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
-  md5: b5325cf06a000c5b14970462ff5e4d58
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/tomli?source=hash-mapping
-  size: 21561
-  timestamp: 1774492402955
 - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
   sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
   md5: 9efbfdc37242619130ea42b1cc4ed861
@@ -15890,18 +13449,6 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110051
   timestamp: 1733367480074
-- conda: https://prefix.dev/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-  sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
-  md5: 4bada6a6d908a27262af8ebddf4f7492
-  depends:
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/traitlets?source=compressed-mapping
-  size: 115165
-  timestamp: 1778074251714
 - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
   sha256: 5e6a3b92c4f99b7b51c646669ad9dbffd307a788fda0001dc82476de8e67ad67
   md5: af104e581c40c72813864454962e1795
@@ -15924,18 +13471,6 @@ packages:
   - pkg:pypi/types-requests?source=hash-mapping
   size: 27102
   timestamp: 1762942302529
-- conda: https://prefix.dev/conda-forge/noarch/types-requests-2.33.0.20260508-pyhcf101f3_0.conda
-  sha256: 956616441704210095c97ac1e2e221427c42be021e8b774efd638f3c5a5229bd
-  md5: e6988fc8330dd047706fa28f3518de6c
-  depends:
-  - python >=3.10
-  - urllib3 >=2
-  - python
-  license: Apache-2.0 AND MIT
-  purls:
-  - pkg:pypi/types-requests?source=compressed-mapping
-  size: 27804
-  timestamp: 1778221311999
 - conda: https://prefix.dev/conda-forge/noarch/types-tqdm-4.67.0.20250809-pyhd8ed1ab_0.conda
   sha256: c181121ab45f6fa15bca0da0c30e94dcd08a0ab65e40afd92ca15570326421f8
   md5: b21e9600b30c5dd4a4855d98889d9c73
@@ -15948,17 +13483,6 @@ packages:
   - pkg:pypi/types-tqdm?source=hash-mapping
   size: 26466
   timestamp: 1754757108681
-- conda: https://prefix.dev/conda-forge/noarch/types-tqdm-4.67.3.20260508-pyhd8ed1ab_0.conda
-  sha256: b19e9225cf7f998d2707ee6c8390824e024d5f377db34f43095551df141dc1dc
-  md5: 9f102a48a7f7d24aa9bd4f529a1cae0f
-  depends:
-  - python >=3.10
-  - types-requests
-  license: Apache-2.0
-  purls:
-  - pkg:pypi/types-tqdm?source=hash-mapping
-  size: 27576
-  timestamp: 1778228974424
 - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   noarch: python
   sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
@@ -16102,17 +13626,6 @@ packages:
   - pkg:pypi/wcwidth?source=compressed-mapping
   size: 71550
   timestamp: 1770634638503
-- conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
-  sha256: 1ee2d8384972ecbf8630ce8a3ea9d16858358ad3e8566675295e66996d5352da
-  md5: eb9538b8e55069434a18547f43b96059
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/wcwidth?source=compressed-mapping
-  size: 82917
-  timestamp: 1777744489106
 - conda: https://prefix.dev/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
   sha256: 21f6c8a20fe050d09bfda3fb0a9c3493936ce7d6e1b3b5f8b01319ee46d6c6f6
   md5: 6639b6b0d8b5a284f027a2003669aa65
@@ -16172,19 +13685,6 @@ packages:
   - pkg:pypi/werkzeug?source=compressed-mapping
   size: 257130
   timestamp: 1771530143814
-- conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
-  sha256: 5108c1bf2f0512e5c9dc8191e31b144c23b7cf0e73423a246173006002368d79
-  md5: 3eeca039e7316268627f4116da9df64c
-  depends:
-  - markupsafe >=2.1.1
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/werkzeug?source=compressed-mapping
-  size: 258232
-  timestamp: 1775160081069
 - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.0-pyhd8ed1ab_0.conda
   sha256: e9ac3caa3b17bed9bc301a67d3950f84fa37fb34002d2878c46cafb87978401d
   md5: 8fa415e696acd9af59ce0a4425fd1b38
@@ -16222,18 +13722,6 @@ packages:
   - pkg:pypi/zipp?source=compressed-mapping
   size: 24194
   timestamp: 1764460141901
-- conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
-  sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
-  md5: e1c36c6121a7c9c76f2f148f1e83b983
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/zipp?source=compressed-mapping
-  size: 24461
-  timestamp: 1776131454755
 - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
   build_number: 7
   sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
@@ -19607,13 +17095,13 @@ packages:
 - pypi: .
   name: simplecv
   requires_dist:
-  - jaxtyping>=0.2.36,<0.3.0
+  - jaxtyping>=0.2.36
   - numpy>=2.0
   - einops>=0.8.0
   - icecream>=2.1.3
   - opencv-python>=4.10.0
-  - pyserde>=0.20.0,<0.30
-  - typing-extensions>=4.1.0,<4.13.0
+  - pyserde>=0.20.0
+  - typing-extensions>=4.1.0
   - rerun-sdk[datafusion]>=0.32
   - tyro>=0.9.1
   - tqdm
@@ -19846,25 +17334,6 @@ packages:
   - kubernetes ; extra == 'k8s'
   - xprof ; extra == 'xprof'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: matplotlib
-  version: 3.10.9
-  sha256: ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285
-  requires_dist:
-  - contourpy>=1.0.1
-  - cycler>=0.10
-  - fonttools>=4.22.0
-  - kiwisolver>=1.3.1
-  - numpy>=1.23
-  - packaging>=20.0
-  - pillow>=8
-  - pyparsing>=3
-  - python-dateutil>=2.7
-  - meson-python>=0.13.1,<0.17.0 ; extra == 'dev'
-  - pybind11>=2.13.2,!=2.13.3 ; extra == 'dev'
-  - setuptools-scm>=7,<10 ; extra == 'dev'
-  - setuptools>=64 ; extra == 'dev'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl
   name: wrapt
   version: 1.17.3
@@ -19879,15 +17348,6 @@ packages:
   - pyarrow>=22.0.0 ; python_full_version >= '3.14'
   - typing-extensions ; python_full_version < '3.13'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/37/f4/84309ba0a69ba2b4d00b41bcd3c72a8f36865458ce9404b17ad5d2857ef1/vrs-1.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: vrs
-  version: 1.2.2
-  sha256: ffcfde444f0e7464c742599fbd6592fe439d6c909a41a58d57cfa6a1086cc6f8
-  requires_dist:
-  - numpy
-  - typing
-  - dataclasses
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/3a/3f/35f4041a82a68df89fe4af97c8bb44aa492dad924799cbb02078e9e303e6/s3fs-2025.3.0-py3-none-any.whl
   name: s3fs
   version: 2025.3.0
@@ -20045,11 +17505,6 @@ packages:
   - urllib3>=1.25.4,!=2.2.0,<3 ; python_full_version >= '3.10'
   - awscrt==0.29.0 ; extra == 'crt'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl
-  name: protobuf
-  version: 7.34.1
-  sha256: 8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
   name: contourpy
   version: 1.3.3
@@ -20160,14 +17615,6 @@ packages:
   - pyyaml
   - huggingface-hub
   - safetensors
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/6a/74/af3e40919305f16968ea3ab88d84b511d710dd281eb5dafaf4897579dd22/ultralytics_thop-2.0.19-py3-none-any.whl
-  name: ultralytics-thop
-  version: 2.0.19
-  sha256: a180baeb3b83f0f2ad3f3572338cef406b221a57c6d10ca09cfd90f9c892a739
-  requires_dist:
-  - numpy
-  - torch
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/6c/d9/b7140a4f1615195938c7e358c0804bb84271f0d6886b5cbf105c6cb58aae/onnxruntime_gpu-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: onnxruntime-gpu
@@ -20280,18 +17727,6 @@ packages:
   - types-requests ; extra == 'typing'
   - types-shapely ; extra == 'typing'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-  name: onnxruntime
-  version: 1.26.0
-  sha256: 9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6
-  requires_dist:
-  - flatbuffers
-  - numpy>=1.21.6
-  - packaging
-  - protobuf
-  - sympy ; extra == 'symbolic'
-  - ml-dtypes ; extra == 'quantization'
-  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/7e/65/07d5f5c7f7c994f12c768708bd2e17a4f01a2b0f44a1c9eccad872433e2e/matplotlib-3.10.8-cp312-cp312-macosx_11_0_arm64.whl
   name: matplotlib
   version: 3.10.8
@@ -20405,62 +17840,11 @@ packages:
   - changelist==0.5 ; extra == 'dev'
   - spin==0.15 ; extra == 'dev'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/96/9c/c86a018d1cbb3c117f7a83fcc86e74b648edaeacc849b8dbc71dd84171bf/fastcore-1.13.0-py3-none-any.whl
-  name: fastcore
-  version: 1.13.0
-  sha256: d56d5727a65835c1326299afc33a166cfa9977a6720b5e9580314c0eeb0ebbfe
-  requires_dist:
-  - numpy ; extra == 'dev'
-  - nbdev>=0.2.39 ; extra == 'dev'
-  - matplotlib ; extra == 'dev'
-  - pillow ; extra == 'dev'
-  - torch ; extra == 'dev'
-  - pandas ; extra == 'dev'
-  - nbclassic ; extra == 'dev'
-  - pysymbol-llm ; extra == 'dev'
-  - llms-txt ; extra == 'dev'
-  - plum-dispatch ; extra == 'dev'
-  - toolslm ; extra == 'dev'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl
   name: protobuf
   version: 6.33.5
   sha256: cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: fonttools
-  version: 4.62.1
-  sha256: 149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392
-  requires_dist:
-  - lxml>=4.0 ; extra == 'lxml'
-  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
-  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
-  - zopfli>=0.1.4 ; extra == 'woff'
-  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
-  - lz4>=1.7.4.2 ; extra == 'graphite'
-  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
-  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
-  - pycairo ; extra == 'interpolatable'
-  - matplotlib ; extra == 'plot'
-  - sympy ; extra == 'symfont'
-  - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - skia-pathops>=0.5.0 ; extra == 'pathops'
-  - uharfbuzz>=0.45.0 ; extra == 'repacker'
-  - lxml>=4.0 ; extra == 'all'
-  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
-  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
-  - zopfli>=0.1.4 ; extra == 'all'
-  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
-  - lz4>=1.7.4.2 ; extra == 'all'
-  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
-  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
-  - pycairo ; extra == 'all'
-  - matplotlib ; extra == 'all'
-  - sympy ; extra == 'all'
-  - xattr ; sys_platform == 'darwin' and extra == 'all'
-  - skia-pathops>=0.5.0 ; extra == 'all'
-  - uharfbuzz>=0.45.0 ; extra == 'all'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: wrapt
   version: 1.17.3
@@ -20526,42 +17910,6 @@ packages:
   version: 0.5.2
   sha256: 4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/b4/af/ce4df3ca29122d219c45d3e86e5ff9a9df03b8cf31afd76817b662c803a3/tifffile-2026.5.2-py3-none-any.whl
-  name: tifffile
-  version: 2026.5.2
-  sha256: 5129b53b826e768a5b1af26b765eeea75c2d0a227d2d12849617e0737588e105
-  requires_dist:
-  - numpy>=2.1
-  - imagecodecs>=2026.3.6 ; extra == 'codecs'
-  - lxml ; extra == 'xml'
-  - zarr>=3.2.0 ; extra == 'zarr'
-  - fsspec ; extra == 'zarr'
-  - kerchunk ; extra == 'zarr'
-  - matplotlib ; extra == 'plot'
-  - imagecodecs>=2026.3.6 ; extra == 'all'
-  - matplotlib ; extra == 'all'
-  - lxml ; extra == 'all'
-  - zarr>=3.2.0 ; extra == 'all'
-  - xarray ; extra == 'all'
-  - fsspec ; extra == 'all'
-  - kerchunk ; extra == 'all'
-  - cmapfile ; extra == 'test'
-  - czifile ; extra == 'test'
-  - dask ; extra == 'test'
-  - fsspec ; extra == 'test'
-  - imagecodecs ; extra == 'test'
-  - kerchunk ; extra == 'test'
-  - lfdfiles ; extra == 'test'
-  - lxml ; extra == 'test'
-  - ndtiff ; extra == 'test'
-  - oiffile ; extra == 'test'
-  - psdtags ; extra == 'test'
-  - pytest ; extra == 'test'
-  - requests ; extra == 'test'
-  - roifile ; extra == 'test'
-  - xarray ; extra == 'test'
-  - zarr>=3.2.0 ; extra == 'test'
-  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/b5/57/89727baef7578897af5ed166735ceb315819f1c184da8c3441271dbcfde7/protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl
   name: protobuf
   version: 7.34.0
@@ -20665,17 +18013,6 @@ packages:
   - pandas>=2 ; extra == 'all'
   - rerun-notebook==0.32.0 ; extra == 'all'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/be/cc/320798a96109bfd7cc4cb8d40431faa0b90256b5123f80ffc08ca98eaf18/lovely_numpy-0.2.23-py3-none-any.whl
-  name: lovely-numpy
-  version: 0.2.23
-  sha256: 909977aeac0e5c8937d149a459f5a090ebafcf2891f1ba38c6884d4c0350bda9
-  requires_dist:
-  - numpy>=1.17
-  - fastcore
-  - matplotlib>=3.4.0
-  - scipy ; extra == 'dev'
-  - ipython ; extra == 'dev'
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c0/84/c87be2b1c58172ed64c2207f1dd116003a84087a9c5112ceb8e37a2233b9/lovely_numpy-0.2.20-py3-none-any.whl
   name: lovely-numpy
   version: 0.2.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,14 @@ description = "Download Aria Gen2 Pilot sequences from CDN URLs"
 cmd = "python tools/preprocess_aria_gen2_pilot.py"
 description = "Convert Aria Gen2 Pilot VRS files to AV1 MP4 for simplecv"
 
+[tool.pixi.tasks.preprocess-epfl-smart-kitchen]
+cmd = "python tools/preprocess_epfl_smart_kitchen.py"
+description = "Build an AV1-transcoded EPFL-Smart-Kitchen mirror for simplecv"
+
 [tool.pixi.tasks.catalog]
+# Keep the default task fast for interactive browsing. Without
+# --no-optimize-for-catalog, SimpleCV pre-optimizes missing RRD cache copies before Rerun registration/ingestion;
+# on a cold full catalog this can be hundreds of GB of serial startup work.
 cmd = "python tools/catalog.py --rrd-root /mnt/8tb/data/exoego-forge-catalog --no-optimize-for-catalog"
 description = "Host the ExoEgo Forge RRD catalog index"
 
@@ -101,6 +108,11 @@ description = "Downloads an example easymocap dataset from huggingface, this may
 cmd = "test -e data/hocap/sample.zip && test -e data/hocap/sample || (mkdir -p data/hocap/ && huggingface-cli download pablovela5620/hocap-sample sample.zip --repo-type dataset --local-dir data/hocap/ && unzip -o data/hocap/sample.zip -d data/hocap/)"
 outputs = ["data/hocap/sample.zip", "data/hocap/sample"]
 description = "Downloads and extracts an example HOCap dataset from huggingface, this may take a while"
+
+[tool.pixi.tasks._download-epfl-smart-kitchen-sample]
+cmd = "test -e data/epfl-smart-kitchen/sample.zip && test -e data/epfl-smart-kitchen/sample || (mkdir -p data/epfl-smart-kitchen/ && huggingface-cli download pablovela5620/epfl-smart-kitchen-sample sample.zip --repo-type dataset --local-dir data/epfl-smart-kitchen/ && unzip -o data/epfl-smart-kitchen/sample.zip -d data/epfl-smart-kitchen/)"
+outputs = ["data/epfl-smart-kitchen/sample.zip", "data/epfl-smart-kitchen/sample"]
+description = "Downloads and extracts an example EPFL-Smart-Kitchen dataset from huggingface"
 
 [tool.pixi.tasks._download-assembly101-sample]
 cmd = """

--- a/simplecv/apis/batch_raw_to_rrd.py
+++ b/simplecv/apis/batch_raw_to_rrd.py
@@ -29,6 +29,14 @@ class BatchConvertConfig:
     """When ``True``, only report the sequences that would be converted without writing files."""
     force: bool = False
     """When ``True``, overwrite existing ``.rrd`` files instead of skipping them."""
+    log_exo: bool = True
+    """Enable exo-camera imagery, intrinsics, and projections during conversion."""
+    log_ego: bool = True
+    """Enable ego-camera imagery, intrinsics, and projections during conversion."""
+    log_labels: bool = True
+    """Enable COCO-133 label logging during conversion."""
+    log_mano: bool = True
+    """Enable derived MANO mesh/keypoint logging during conversion."""
 
 
 def main(config: BatchConvertConfig):
@@ -69,6 +77,10 @@ def main(config: BatchConvertConfig):
                     save=rrd_save_path,
                 ),
                 dataset=current_exoego_sequence.config,
+                log_exo=config.log_exo,
+                log_ego=config.log_ego,
+                log_labels=config.log_labels,
+                log_mano=config.log_mano,
             )
             rec: rr.RecordingStream = current_cfg.rr_config.rec_stream
             rr.send_recording_name(identity.sequence_key, recording=rec)
@@ -82,6 +94,7 @@ def main(config: BatchConvertConfig):
                 ),
             )
             visualize_exo_ego(current_exoego_sequence, current_cfg)
+            rec.flush(timeout_sec=600.0)
 
         if config.max_conversions is not None and idx + 1 >= config.max_conversions:
             break

--- a/simplecv/apis/exoego_forge_catalog.py
+++ b/simplecv/apis/exoego_forge_catalog.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 
 import atexit
 import base64
+import os
 import subprocess
 import tempfile
+import threading
 import time
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import pyarrow as pa
 import rerun as rr
@@ -35,12 +37,15 @@ TABLE_CARD_PREVIEW_START_SECONDS: float = 0.0
 """Start of the absolute ``video_time`` loop used by table-card previews."""
 TABLE_CARD_PREVIEW_END_SECONDS: float = 10.0
 """End of the absolute ``video_time`` loop used by table-card previews."""
+CATALOG_SHUTDOWN_TIMEOUT_SECONDS: float = 5.0
+"""Maximum graceful shutdown wait after Ctrl-C before forcing process exit."""
 DEFAULT_CATALOG_RRD_CACHE_DIR: Path = Path("~/.cache/simplecv/exoego-forge-catalog-optimized")
 """Default persistent cache root for catalog-compatible optimized RRD copies."""
 
 DEFAULT_CATALOG_DATASETS: tuple[str, ...] = (
     "aria-gen2",
     "assembly101",
+    "epfl-smart-kitchen",
     "hocap",
     "hot3d-aria",
     "hot3d-quest3",
@@ -51,6 +56,7 @@ DEFAULT_CATALOG_DATASETS: tuple[str, ...] = (
 DEFAULT_CATALOG_OPTIMIZE_DATASETS: tuple[str, ...] = (
     "aria-gen2",
     "assembly101",
+    "epfl-smart-kitchen",
     "hocap",
     "hot3d-aria",
     "hot3d-quest3",
@@ -75,6 +81,20 @@ CATALOG_CAMERA_NAMES: dict[str, dict[str, tuple[str, ...]]] = {
     "assembly101": {
         "ego": ("e1", "e2", "e3", "e4"),
         "exo": ("C10095", "C10115", "C10118", "C10119", "C10379", "C10390", "C10395", "C10404"),
+    },
+    "epfl-smart-kitchen": {
+        "ego": ("hololens",),
+        "exo": (
+            "output0",
+            "Aoutput0",
+            "Aoutput1",
+            "Aoutput2",
+            "Aoutput3",
+            "Boutput0",
+            "Boutput1",
+            "Boutput2",
+            "Boutput3",
+        ),
     },
     "hocap": {
         "ego": ("hololens_kv5h72",),
@@ -111,6 +131,36 @@ CATALOG_TABLE_PREVIEW_CAMERAS: dict[str, tuple[str, str]] = {
     "assembly101": ("ego", "e3"),
 }
 """Dataset-specific table-card video preview overrides."""
+
+
+@runtime_checkable
+class CatalogServer(Protocol):
+    """Minimal server interface used by catalog registration."""
+
+    def url(self) -> str:
+        """Return the catalog URL."""
+        ...
+
+    def client(self) -> Any:
+        """Return a Rerun catalog client."""
+        ...
+
+    def shutdown(self) -> None:
+        """Stop the catalog server."""
+        ...
+
+    def __enter__(self) -> CatalogServer:
+        """Enter the server context manager."""
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: Any | None,
+    ) -> None:
+        """Exit the server context manager."""
+        ...
 
 
 def build_exoego_catalog_blueprint(dataset_name: str) -> rrb.Blueprint:
@@ -233,8 +283,7 @@ def discover_rrd_uris(
     """
     paths_by_dataset: dict[str, list[Path]] = discover_rrd_paths(rrd_root, datasets=datasets)
     uris_by_dataset: dict[str, list[str]] = {
-        dataset_name: [path.as_uri() for path in rrd_paths]
-        for dataset_name, rrd_paths in paths_by_dataset.items()
+        dataset_name: [path.as_uri() for path in rrd_paths] for dataset_name, rrd_paths in paths_by_dataset.items()
     }
     return uris_by_dataset
 
@@ -287,8 +336,7 @@ def _optimize_rrd_for_catalog(source_path: Path, *, rrd_root: Path, cache_root: 
     )
     if completed_process.returncode != 0:
         raise RuntimeError(
-            f"Failed to optimize {source_resolved} for Rerun catalog registration.\n"
-            f"{completed_process.stderr.strip()}"
+            f"Failed to optimize {source_resolved} for Rerun catalog registration.\n{completed_process.stderr.strip()}"
         )
 
     tmp_path.replace(optimized_path)
@@ -305,7 +353,7 @@ def mount_catalog(
     optimize_for_catalog: bool = True,
     catalog_rrd_cache_dir: Path = DEFAULT_CATALOG_RRD_CACHE_DIR,
     optimize_datasets: tuple[str, ...] = DEFAULT_CATALOG_OPTIMIZE_DATASETS,
-) -> rr.server.Server:
+) -> CatalogServer:
     """Mount local ExoEgo Forge RRDs as one Rerun catalog dataset per source.
 
     The default path registers optimized cache copies rather than raw source
@@ -539,7 +587,9 @@ def build_rrd_index_rows_from_dataset(
     segment_table: pa.Table = pa.Table.from_batches(segment_batches)
     if segment_table.num_rows == 0:
         raise FileNotFoundError(f"Registered {dataset_name} dataset has no segments.")
-    recording_ids: list[str] = [str(recording_id) for recording_id in segment_table.column("rerun_segment_id").to_pylist()]
+    recording_ids: list[str] = [
+        str(recording_id) for recording_id in segment_table.column("rerun_segment_id").to_pylist()
+    ]
     sequence_key_values: list[Any | None] = _optional_segment_column_values(segment_table, "property:info:sequence_key")
 
     rows: list[RRDIndexRow] = []
@@ -693,8 +743,7 @@ def build_rrd_index_table_blueprint(dataset_name: str, *, timeline: str = "video
     table_blueprint_archetype: Any | None = getattr(experimental_api, "TableBlueprint", None)
     if table_blueprint_archetype is None:
         raise RuntimeError(
-            "Experimental table blueprints require Rerun SDK 0.32 or newer. "
-            "Run from the default Pixi environment."
+            "Experimental table blueprints require Rerun SDK 0.32 or newer. Run from the default Pixi environment."
         )
 
     blueprint: rrb.Blueprint = build_table_card_blueprint(dataset_name, timeline=timeline)
@@ -774,6 +823,10 @@ def create_rrd_index_table(
     if table_name in existing_table_names:
         client.get_table(table_name).delete()
 
+    # The embedded TableBlueprint enables preview cards for each catalog row.
+    # Creating these previews can dominate startup for large datasets, but they
+    # are intentionally kept because the catalog is much less useful without
+    # visual row previews.
     encoded_blueprint: str = build_rrd_index_table_blueprint(dataset_name)
     schema: pa.Schema = build_rrd_index_table_schema(encoded_blueprint)
     table = client.create_table(table_name, schema)
@@ -789,6 +842,44 @@ def create_rrd_index_table(
     return table
 
 
+def _shutdown_catalog_server(server: CatalogServer, *, timeout_seconds: float = CATALOG_SHUTDOWN_TIMEOUT_SECONDS) -> bool:
+    """Shutdown a Rerun server without letting native teardown block forever.
+
+    Args:
+        server: Running Rerun catalog server.
+        timeout_seconds: Maximum time to wait for graceful shutdown.
+
+    Returns:
+        True when shutdown completed before the timeout, false otherwise.
+
+    Raises:
+        RuntimeError: If the shutdown thread returns an exception.
+    """
+    shutdown_errors: list[BaseException] = []
+
+    def shutdown() -> None:
+        try:
+            server.shutdown()
+        except BaseException as exc:  # noqa: BLE001 - relay shutdown failures from the worker thread.
+            shutdown_errors.append(exc)
+
+    shutdown_thread: threading.Thread = threading.Thread(
+        target=shutdown,
+        name="rerun-catalog-shutdown",
+        daemon=True,
+    )
+    shutdown_thread.start()
+    try:
+        shutdown_thread.join(timeout=timeout_seconds)
+    except KeyboardInterrupt:
+        return False
+    if shutdown_thread.is_alive():
+        return False
+    if shutdown_errors:
+        raise RuntimeError("Rerun catalog server shutdown failed.") from shutdown_errors[0]
+    return True
+
+
 def main(config: CatalogConfig) -> None:
     """Host a Rerun catalog for converted ExoEgo Forge RRD files.
 
@@ -799,17 +890,21 @@ def main(config: CatalogConfig) -> None:
     paths_by_dataset: dict[str, list[Path]] = discover_rrd_paths(rrd_root, datasets=config.datasets)
     dataset_names: list[str] = sorted(paths_by_dataset)
 
-    with mount_catalog(
-        rrd_root,
-        datasets=config.datasets,
-        port=config.port,
-        application_id=config.application_id,
-        optimize_for_catalog=config.optimize_for_catalog,
-        catalog_rrd_cache_dir=config.catalog_rrd_cache_dir,
-        optimize_datasets=config.optimize_datasets,
-    ) as server:
+    server: CatalogServer | None = None
+    client: Any | None = None
+    try:
+        server = mount_catalog(
+            rrd_root,
+            datasets=config.datasets,
+            port=config.port,
+            application_id=config.application_id,
+            optimize_for_catalog=config.optimize_for_catalog,
+            catalog_rrd_cache_dir=config.catalog_rrd_cache_dir,
+            optimize_datasets=config.optimize_datasets,
+        )
         client = server.client()
         table_urls_by_name: dict[str, str] = {}
+        catalog_url: str = server.url()
         for dataset_name in dataset_names:
             dataset_dir: Path = rrd_root / dataset_name
             dataset_entry = client.get_dataset(dataset_name)
@@ -827,12 +922,11 @@ def main(config: CatalogConfig) -> None:
                 table_name=table_name,
                 rows=rows,
             )
-            table_urls_by_name[table_name] = f"{server.url()}/entry/{table.id}"
+            table_urls_by_name[table_name] = f"{catalog_url}/entry/{table.id}"
 
-        url: str = server.url()
         print()
         print("-" * 72)
-        print(f"  Catalog URL:  {url}")
+        print(f"  Catalog URL:  {catalog_url}")
         print()
         print("  Tables:")
         for table_name, table_url in table_urls_by_name.items():
@@ -846,12 +940,23 @@ def main(config: CatalogConfig) -> None:
         print("-" * 72, flush=True)
 
         if config.open_browser:
-            rr.serve_web_viewer(web_port=config.web_port, open_browser=True, connect_to=url)
-            print(f"\nWeb viewer hosted at http://127.0.0.1:{config.web_port} with the catalog loaded.")
+            rr.serve_web_viewer(web_port=config.web_port, open_browser=True, connect_to=catalog_url)
+            print(f"\nWeb viewer hosted at http://127.0.0.1:{config.web_port}")
 
         print("\nServer is up. Ctrl-C to stop.", flush=True)
         try:
             while True:
                 time.sleep(3600)
         except KeyboardInterrupt:
-            print("shutting down")
+            print("shutting down", flush=True)
+    finally:
+        client = None
+        if server is not None:
+            shutdown_completed: bool = _shutdown_catalog_server(server)
+            if not shutdown_completed:
+                print(
+                    f"Rerun catalog server did not shut down within {CATALOG_SHUTDOWN_TIMEOUT_SECONDS:.1f}s; "
+                    "forcing process exit.",
+                    flush=True,
+                )
+                os._exit(130)

--- a/simplecv/apis/preprocess_epfl_smart_kitchen.py
+++ b/simplecv/apis/preprocess_epfl_smart_kitchen.py
@@ -1,0 +1,706 @@
+"""Build an AV1-transcoded EPFL-Smart-Kitchen mirror for SimpleCV."""
+
+from __future__ import annotations
+
+import csv
+import json
+import shutil
+import subprocess
+import time
+import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Literal
+
+from tqdm import tqdm
+
+EPFL_SOURCE_ROOT: Path = Path("/mnt/8tb/data/epfl-smart-kitchen")
+EPFL_AV1_MIRROR_ROOT: Path = Path("/mnt/8tb/data/epfl-smart-kitchen-av1")
+VIDEO_DIR_NAMES: tuple[str, str] = ("videos", "videos_depth")
+GENERATED_VIDEO_SUFFIXES: tuple[str, str] = (".rerun_h264.mp4", ".rerun_av1.mp4")
+GENERATED_FILENAMES: set[str] = {"av1_encode_report.md", "av1_encode_report.json"}
+GENERATED_DIR_SUFFIXES: tuple[str, ...] = ("-av1-test",)
+EXCLUDED_ARCHIVE_SUFFIXES: tuple[str, ...] = (".zip",)
+
+
+@dataclass(frozen=True)
+class MirrorCopyJob:
+    """A byte-for-byte metadata or annotation copy in the AV1 mirror."""
+
+    source_path: Path
+    """Source file in the original EPFL tree."""
+    target_path: Path
+    """Target file in the AV1 mirror tree."""
+    relative_path: Path
+    """Path relative to the dataset root."""
+
+
+@dataclass(frozen=True)
+class MirrorVideoJob:
+    """A video transcode from source MP4 to AV1 MP4."""
+
+    source_path: Path
+    """Source MP4 in the original EPFL tree."""
+    target_path: Path
+    """Target AV1 MP4 in the mirror tree."""
+    relative_path: Path
+    """Path relative to the dataset root."""
+    group: Literal["videos", "videos_depth"]
+    """EPFL video directory type."""
+
+
+@dataclass(frozen=True)
+class EpflMirrorPlan:
+    """Full file operation plan for an EPFL AV1 mirror."""
+
+    source_root: Path
+    """Original EPFL dataset root."""
+    target_root: Path
+    """AV1 mirror dataset root."""
+    video_jobs: tuple[MirrorVideoJob, ...]
+    """Video files to transcode to AV1."""
+    copy_jobs: tuple[MirrorCopyJob, ...]
+    """Non-video files to copy byte-for-byte."""
+
+
+@dataclass(frozen=True)
+class VideoProbe:
+    """Selected ffprobe metadata for one video stream."""
+
+    path: str
+    """Video path."""
+    codec_name: str
+    """Video codec name reported by ffprobe."""
+    width: int
+    """Encoded width in pixels."""
+    height: int
+    """Encoded height in pixels."""
+    pix_fmt: str
+    """Pixel format."""
+    duration_sec: float | None
+    """Duration in seconds when available."""
+    frame_count: int | None
+    """Frame count when available."""
+    size_bytes: int
+    """File size in bytes."""
+
+
+@dataclass(frozen=True)
+class EncodeResult:
+    """Manifest row for one AV1 mirror video."""
+
+    relative_path: str
+    """Path relative to the mirror root."""
+    group: str
+    """EPFL video directory type."""
+    status: Literal["dry-run", "encoded", "skipped"]
+    """Operation result."""
+    source_codec: str
+    """Source codec name."""
+    target_codec: str
+    """Target codec name."""
+    width: int
+    """Target width in pixels."""
+    height: int
+    """Target height in pixels."""
+    source_frame_count: int | None
+    """Source frame count when available."""
+    target_frame_count: int | None
+    """Target frame count when available."""
+    source_duration_sec: float | None
+    """Source duration when available."""
+    target_duration_sec: float | None
+    """Target duration when available."""
+    source_size_bytes: int
+    """Source file size in bytes."""
+    target_size_bytes: int
+    """Target file size in bytes."""
+    elapsed_sec: float
+    """Wall-clock encode or validation time."""
+    message: str = ""
+    """Additional validation notes."""
+
+
+@dataclass
+class PreprocessConfig:
+    """Configuration for building the EPFL-Smart-Kitchen AV1 mirror."""
+
+    source_root: Path = EPFL_SOURCE_ROOT
+    """Original EPFL dataset root."""
+    target_root: Path = EPFL_AV1_MIRROR_ROOT
+    """Output root for the AV1-transcoded mirror."""
+    sequence_key: str = ""
+    """Optional single sequence filter, for example ``train/YH2002/2023_12_04_10_15_23``."""
+    include_depth: bool = True
+    """When ``True``, transcode ``videos_depth/*.mp4`` in addition to RGB/HoloLens videos."""
+    num_workers: int = 1
+    """Number of concurrent ffmpeg transcodes. Keep low for NVENC session limits."""
+    force: bool = False
+    """When ``True``, re-encode existing target MP4s."""
+    dry_run: bool = False
+    """When ``True``, print the plan without copying or encoding."""
+    max_videos: int | None = None
+    """Optional cap on video transcodes for smoke tests."""
+    ffmpeg_path: str = "ffmpeg"
+    """ffmpeg executable."""
+    ffprobe_path: str = "ffprobe"
+    """ffprobe executable."""
+    preset: str = "p5"
+    """NVENC AV1 preset."""
+    tune: str = "hq"
+    """NVENC tune."""
+    cq: int = 38
+    """NVENC constant quality value."""
+    duration_tolerance_sec: float = 0.25
+    """Allowed absolute duration difference between source and AV1 target."""
+    count_frames: bool = False
+    """When ``True``, ask ffprobe to decode/count frames for slower exact validation."""
+
+
+def _is_generated_path(relative_path: Path) -> bool:
+    """Return whether ``relative_path`` is generated output that must not enter the mirror."""
+    if relative_path.name in GENERATED_FILENAMES:
+        return True
+    if relative_path.suffix.lower() in EXCLUDED_ARCHIVE_SUFFIXES:
+        return True
+    if any(part.endswith(GENERATED_DIR_SUFFIXES) for part in relative_path.parts):
+        return True
+    return relative_path.name.endswith(GENERATED_VIDEO_SUFFIXES)
+
+
+def _is_video_path(relative_path: Path, *, include_depth: bool) -> bool:
+    """Return whether ``relative_path`` is an EPFL video payload file."""
+    if relative_path.suffix.lower() != ".mp4":
+        return False
+    parent_name: str = relative_path.parent.name
+    if parent_name == "videos":
+        return True
+    return bool(include_depth and parent_name == "videos_depth")
+
+
+def _matches_sequence_key(relative_path: Path, sequence_key: str) -> bool:
+    """Return whether ``relative_path`` belongs to an optional EPFL sequence key."""
+    if not sequence_key:
+        return True
+    sequence_relative_path: Path = Path(sequence_key)
+    prefixes: tuple[Path, Path] = (
+        Path("Public_release_videos") / sequence_relative_path,
+        Path("Public_release_pose") / sequence_relative_path,
+    )
+    return any(relative_path == prefix or relative_path.is_relative_to(prefix) for prefix in prefixes)
+
+
+def build_mirror_plan(
+    *,
+    source_root: Path,
+    target_root: Path,
+    sequence_key: str = "",
+    include_depth: bool = True,
+    max_videos: int | None = None,
+) -> EpflMirrorPlan:
+    """Build the copy/transcode plan for an EPFL AV1 mirror.
+
+    Args:
+        source_root: Original EPFL dataset root.
+        target_root: AV1 mirror target root.
+        sequence_key: Optional ``split/participant/session`` filter.
+        include_depth: Include ``videos_depth/*.mp4`` when true.
+        max_videos: Optional cap for smoke-test encodes.
+
+    Returns:
+        Deterministic mirror operation plan.
+    """
+    if not source_root.exists():
+        raise FileNotFoundError(f"EPFL source root does not exist: {source_root}")
+    if source_root.resolve() == target_root.resolve():
+        raise ValueError("EPFL AV1 mirror target_root must differ from source_root")
+
+    video_jobs: list[MirrorVideoJob] = []
+    copy_jobs: list[MirrorCopyJob] = []
+    source_paths: list[Path] = sorted(path for path in source_root.rglob("*") if path.is_file())
+    for source_path in source_paths:
+        relative_path: Path = source_path.relative_to(source_root)
+        if _is_generated_path(relative_path):
+            continue
+        if not _matches_sequence_key(relative_path, sequence_key):
+            continue
+        target_path: Path = target_root / relative_path
+        if _is_video_path(relative_path, include_depth=include_depth):
+            group: Literal["videos", "videos_depth"] = "videos_depth" if relative_path.parent.name == "videos_depth" else "videos"
+            video_jobs.append(
+                MirrorVideoJob(
+                    source_path=source_path,
+                    target_path=target_path,
+                    relative_path=relative_path,
+                    group=group,
+                )
+            )
+        else:
+            copy_jobs.append(
+                MirrorCopyJob(
+                    source_path=source_path,
+                    target_path=target_path,
+                    relative_path=relative_path,
+                )
+            )
+    if max_videos is not None:
+        video_jobs = video_jobs[:max_videos]
+    return EpflMirrorPlan(
+        source_root=source_root,
+        target_root=target_root,
+        video_jobs=tuple(video_jobs),
+        copy_jobs=tuple(copy_jobs),
+    )
+
+
+def dataset_card_text() -> str:
+    """Return the Hugging Face dataset card for the EPFL AV1 mirror."""
+    return """---
+license: cc-by-nc-4.0
+tags:
+- video
+- computer-vision
+- epfl-smart-kitchen
+- simplecv
+- av1
+pretty_name: EPFL-Smart-Kitchen AV1 SimpleCV Mirror
+---
+
+# EPFL-Smart-Kitchen AV1 SimpleCV Mirror
+
+This is an AV1-transcoded SimpleCV-compatible mirror of the EPFL-Smart-Kitchen-30 dataset.
+
+Original data:
+
+- Collected videos/data: https://zenodo.org/records/15535461
+- Poses/annotations: https://zenodo.org/records/15551913
+- GitHub: https://github.com/amathislab/EPFL-Smart-Kitchen
+
+## Contents
+
+- RGB and HoloLens videos transcoded to AV1 MP4
+- Depth videos transcoded to AV1 MP4
+- Metadata, timestamps, IMUs, poses, and annotations preserved from the local release
+- Manifests for sequence inventory and encode validation
+
+## Important Notes
+
+- Videos were transcoded from the original MP4 release using NVIDIA NVENC AV1.
+- This mirror is intended for non-commercial research use.
+- Use the official Zenodo records for the canonical release.
+
+## License
+
+Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0).
+See `LICENSE`.
+"""
+
+
+def license_text() -> str:
+    """Return a short license pointer for the mirrored dataset."""
+    return """Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+
+See https://creativecommons.org/licenses/by-nc/4.0/
+
+The original EPFL-Smart-Kitchen Zenodo records describe the public release as CC BY-NC 4.0.
+"""
+
+
+def _run_json(command: list[str]) -> dict[str, Any]:
+    """Run a command that emits JSON and return the parsed object."""
+    process: subprocess.CompletedProcess[str] = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    data: dict[str, Any] = json.loads(process.stdout)
+    return data
+
+
+def _optional_int(value: object) -> int | None:
+    """Parse an optional ffprobe integer field."""
+    if value is None or value == "N/A":
+        return None
+    return int(value)
+
+
+def _optional_float(value: object) -> float | None:
+    """Parse an optional ffprobe float field."""
+    if value is None or value == "N/A":
+        return None
+    return float(value)
+
+
+def probe_video(video_path: Path, *, ffprobe_path: str = "ffprobe", count_frames: bool = False) -> VideoProbe:
+    """Probe one video's codec, dimensions, frame count, duration, and size."""
+    stream_entries: str = "stream=codec_name,width,height,pix_fmt,nb_frames,duration"
+    command: list[str] = [
+        ffprobe_path,
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+    ]
+    if count_frames:
+        command.append("-count_frames")
+        stream_entries = "stream=codec_name,width,height,pix_fmt,nb_frames,nb_read_frames,duration"
+    command.extend(
+        [
+            "-show_entries",
+            stream_entries,
+            "-show_entries",
+            "format=duration,size",
+            "-of",
+            "json",
+            str(video_path),
+        ]
+    )
+    data: dict[str, Any] = _run_json(
+        command
+    )
+    streams: list[dict[str, Any]] = data.get("streams", [])
+    if not streams:
+        raise ValueError(f"No video stream found in {video_path}")
+    stream: dict[str, Any] = streams[0]
+    format_info: dict[str, Any] = data.get("format", {})
+    frame_count: int | None = _optional_int(stream.get("nb_read_frames"))
+    if frame_count is None:
+        frame_count = _optional_int(stream.get("nb_frames"))
+    duration_sec: float | None = _optional_float(stream.get("duration"))
+    if duration_sec is None:
+        duration_sec = _optional_float(format_info.get("duration"))
+    return VideoProbe(
+        path=str(video_path),
+        codec_name=str(stream["codec_name"]),
+        width=int(stream["width"]),
+        height=int(stream["height"]),
+        pix_fmt=str(stream["pix_fmt"]),
+        duration_sec=duration_sec,
+        frame_count=frame_count,
+        size_bytes=int(format_info.get("size") or video_path.stat().st_size),
+    )
+
+
+def _validate_target_probe(
+    *,
+    source_probe: VideoProbe,
+    target_probe: VideoProbe,
+    duration_tolerance_sec: float,
+) -> str:
+    """Validate target AV1 stream compatibility and return non-fatal notes."""
+    messages: list[str] = []
+    if target_probe.codec_name != "av1":
+        raise ValueError(f"Expected AV1 target codec, got {target_probe.codec_name}: {target_probe.path}")
+    if target_probe.pix_fmt != "yuv420p":
+        raise ValueError(f"Expected yuv420p target pixel format, got {target_probe.pix_fmt}: {target_probe.path}")
+    if (target_probe.width, target_probe.height) != (source_probe.width, source_probe.height):
+        raise ValueError(
+            "Target dimensions do not match source: "
+            f"{source_probe.width}x{source_probe.height} -> {target_probe.width}x{target_probe.height}"
+        )
+    if (
+        source_probe.frame_count is not None
+        and target_probe.frame_count is not None
+        and source_probe.frame_count != target_probe.frame_count
+    ):
+        warnings.warn(
+            f"Target frame count does not match source: {source_probe.frame_count} -> {target_probe.frame_count}",
+            stacklevel=2,
+        )
+        messages.append("frame_count_mismatch")
+    if source_probe.duration_sec is not None and target_probe.duration_sec is not None:
+        duration_delta_sec: float = abs(source_probe.duration_sec - target_probe.duration_sec)
+        if duration_delta_sec > duration_tolerance_sec:
+            raise ValueError(
+                f"Target duration differs from source by {duration_delta_sec:.3f}s, "
+                f"tolerance is {duration_tolerance_sec:.3f}s"
+            )
+    if target_probe.size_bytes >= source_probe.size_bytes:
+        messages.append("target_not_smaller_than_source")
+    return ";".join(messages)
+
+
+def _encode_command(job: MirrorVideoJob, tmp_path: Path, config: PreprocessConfig) -> list[str]:
+    """Build the ffmpeg AV1 NVENC command for one mirror video."""
+    return [
+        config.ffmpeg_path,
+        "-hide_banner",
+        "-y",
+        "-loglevel",
+        "error",
+        "-i",
+        str(job.source_path),
+        "-map",
+        "0:v:0",
+        "-c:v",
+        "av1_nvenc",
+        "-preset",
+        config.preset,
+        "-tune",
+        config.tune,
+        "-rc",
+        "vbr",
+        "-cq",
+        str(config.cq),
+        "-b:v",
+        "0",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        str(tmp_path),
+    ]
+
+
+def encode_video(job: MirrorVideoJob, config: PreprocessConfig) -> EncodeResult:
+    """Encode or validate one AV1 mirror video."""
+    start_time: float = time.perf_counter()
+    source_probe: VideoProbe = probe_video(
+        job.source_path,
+        ffprobe_path=config.ffprobe_path,
+        count_frames=config.count_frames,
+    )
+    if job.target_path.exists() and not config.force:
+        target_probe: VideoProbe = probe_video(
+            job.target_path,
+            ffprobe_path=config.ffprobe_path,
+            count_frames=config.count_frames,
+        )
+        message: str = _validate_target_probe(
+            source_probe=source_probe,
+            target_probe=target_probe,
+            duration_tolerance_sec=config.duration_tolerance_sec,
+        )
+        return _encode_result(
+            job=job,
+            status="skipped",
+            source_probe=source_probe,
+            target_probe=target_probe,
+            elapsed_sec=time.perf_counter() - start_time,
+            message=message,
+        )
+
+    job.target_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path = job.target_path.with_name(f"{job.target_path.name}.tmp.mp4")
+    if tmp_path.exists():
+        tmp_path.unlink()
+    command: list[str] = _encode_command(job, tmp_path, config)
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"ffmpeg executable not found: {config.ffmpeg_path}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr: str = exc.stderr or ""
+        if "Unknown encoder 'av1_nvenc'" in stderr or "av1_nvenc" in stderr:
+            raise RuntimeError(
+                "ffmpeg failed to use the av1_nvenc encoder. Confirm this ffmpeg build has NVIDIA AV1 NVENC "
+                "support and that the NVIDIA driver exposes an AV1-capable GPU."
+            ) from exc
+        raise
+    tmp_path.replace(job.target_path)
+
+    target_probe = probe_video(job.target_path, ffprobe_path=config.ffprobe_path, count_frames=config.count_frames)
+    message = _validate_target_probe(
+        source_probe=source_probe,
+        target_probe=target_probe,
+        duration_tolerance_sec=config.duration_tolerance_sec,
+    )
+    return _encode_result(
+        job=job,
+        status="encoded",
+        source_probe=source_probe,
+        target_probe=target_probe,
+        elapsed_sec=time.perf_counter() - start_time,
+        message=message,
+    )
+
+
+def _encode_result(
+    *,
+    job: MirrorVideoJob,
+    status: Literal["encoded", "skipped"],
+    source_probe: VideoProbe,
+    target_probe: VideoProbe,
+    elapsed_sec: float,
+    message: str,
+) -> EncodeResult:
+    """Create an encode manifest row from probes."""
+    return EncodeResult(
+        relative_path=job.relative_path.as_posix(),
+        group=job.group,
+        status=status,
+        source_codec=source_probe.codec_name,
+        target_codec=target_probe.codec_name,
+        width=target_probe.width,
+        height=target_probe.height,
+        source_frame_count=source_probe.frame_count,
+        target_frame_count=target_probe.frame_count,
+        source_duration_sec=source_probe.duration_sec,
+        target_duration_sec=target_probe.duration_sec,
+        source_size_bytes=source_probe.size_bytes,
+        target_size_bytes=target_probe.size_bytes,
+        elapsed_sec=elapsed_sec,
+        message=message,
+    )
+
+
+def copy_metadata_files(copy_jobs: tuple[MirrorCopyJob, ...], *, force: bool) -> int:
+    """Copy non-video files and return the number of files written."""
+    copied_count: int = 0
+    for job in tqdm(copy_jobs, desc="Copy metadata", unit="file"):
+        should_copy: bool = force or not job.target_path.exists()
+        if not should_copy:
+            source_stat = job.source_path.stat()
+            target_stat = job.target_path.stat()
+            should_copy = source_stat.st_size != target_stat.st_size or source_stat.st_mtime > target_stat.st_mtime
+        if should_copy:
+            job.target_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(job.source_path, job.target_path)
+            copied_count += 1
+    return copied_count
+
+
+def _sequence_key_from_relative_path(relative_path: Path) -> tuple[str, str, str] | None:
+    """Extract ``split/participant/session`` from a mirrored EPFL relative path."""
+    parts: tuple[str, ...] = relative_path.parts
+    if len(parts) < 4 or parts[0] not in {"Public_release_pose", "Public_release_videos"}:
+        return None
+    return parts[1], parts[2], parts[3]
+
+
+def write_sequence_manifest(plan: EpflMirrorPlan, manifest_dir: Path) -> Path:
+    """Write a per-sequence inventory manifest."""
+    rows_by_key: dict[tuple[str, str, str], dict[str, int | str | bool]] = {}
+    for job in plan.video_jobs:
+        key: tuple[str, str, str] | None = _sequence_key_from_relative_path(job.relative_path)
+        if key is None:
+            continue
+        row: dict[str, int | str | bool] = rows_by_key.setdefault(
+            key,
+            {
+                "split": key[0],
+                "participant_id": key[1],
+                "session_name": key[2],
+                "has_pose": False,
+                "num_rgb_videos": 0,
+                "num_depth_videos": 0,
+            },
+        )
+        if job.group == "videos_depth":
+            row["num_depth_videos"] = int(row["num_depth_videos"]) + 1
+        else:
+            row["num_rgb_videos"] = int(row["num_rgb_videos"]) + 1
+    for job in plan.copy_jobs:
+        key = _sequence_key_from_relative_path(job.relative_path)
+        if key is None or job.relative_path.parts[0] != "Public_release_pose":
+            continue
+        row = rows_by_key.setdefault(
+            key,
+            {
+                "split": key[0],
+                "participant_id": key[1],
+                "session_name": key[2],
+                "has_pose": False,
+                "num_rgb_videos": 0,
+                "num_depth_videos": 0,
+            },
+        )
+        row["has_pose"] = True
+
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    path: Path = manifest_dir / "sequences.csv"
+    fieldnames: list[str] = ["split", "participant_id", "session_name", "has_pose", "num_rgb_videos", "num_depth_videos"]
+    with path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        for key in sorted(rows_by_key):
+            writer.writerow(rows_by_key[key])
+    return path
+
+
+def write_upload_payload(plan: EpflMirrorPlan, manifest_dir: Path) -> Path:
+    """Write the relative file list expected to be uploaded to Hugging Face."""
+    payload_paths: set[str] = {
+        "README.md",
+        "LICENSE",
+        "manifests/sequences.csv",
+        "manifests/encode_report.csv",
+        "manifests/encode_report.json",
+        "manifests/upload_payload.txt",
+    }
+    payload_paths.update(job.relative_path.as_posix() for job in plan.video_jobs)
+    payload_paths.update(job.relative_path.as_posix() for job in plan.copy_jobs)
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    path: Path = manifest_dir / "upload_payload.txt"
+    path.write_text("\n".join(sorted(payload_paths)) + "\n")
+    return path
+
+
+def write_encode_reports(results: list[EncodeResult], manifest_dir: Path) -> tuple[Path, Path]:
+    """Write CSV and JSON encode reports."""
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    csv_path: Path = manifest_dir / "encode_report.csv"
+    json_path: Path = manifest_dir / "encode_report.json"
+    rows: list[dict[str, Any]] = [asdict(result) for result in results]
+    fieldnames: list[str] = list(rows[0].keys()) if rows else list(EncodeResult.__dataclass_fields__.keys())
+    with csv_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def write_dataset_files(target_root: Path) -> None:
+    """Write top-level Hugging Face dataset files."""
+    target_root.mkdir(parents=True, exist_ok=True)
+    (target_root / "README.md").write_text(dataset_card_text())
+    (target_root / "LICENSE").write_text(license_text())
+
+
+def run_plan(plan: EpflMirrorPlan, config: PreprocessConfig) -> list[EncodeResult]:
+    """Execute copy and encode jobs for an EPFL AV1 mirror plan."""
+    copied_count: int = copy_metadata_files(plan.copy_jobs, force=config.force)
+    print(f"Copied metadata/annotation files: {copied_count}")
+
+    results: list[EncodeResult] = []
+    with ThreadPoolExecutor(max_workers=config.num_workers) as executor:
+        futures = [executor.submit(encode_video, job, config) for job in plan.video_jobs]
+        for future in tqdm(as_completed(futures), total=len(futures), desc="Encode AV1", unit="video"):
+            results.append(future.result())
+    results.sort(key=lambda result: result.relative_path)
+    return results
+
+
+def main(config: PreprocessConfig) -> None:
+    """Build the EPFL AV1 mirror according to ``config``."""
+    plan: EpflMirrorPlan = build_mirror_plan(
+        source_root=config.source_root,
+        target_root=config.target_root,
+        sequence_key=config.sequence_key,
+        include_depth=config.include_depth,
+        max_videos=config.max_videos,
+    )
+    print(f"Source: {plan.source_root}")
+    print(f"Target: {plan.target_root}")
+    print(f"Copy files: {len(plan.copy_jobs)}")
+    print(f"Video transcodes: {len(plan.video_jobs)}")
+    if config.dry_run:
+        return
+
+    effective_config: PreprocessConfig = replace(config)
+    results: list[EncodeResult] = run_plan(plan, effective_config)
+    manifest_dir: Path = config.target_root / "manifests"
+    write_dataset_files(config.target_root)
+    write_sequence_manifest(plan, manifest_dir)
+    write_encode_reports(results, manifest_dir)
+    write_upload_payload(plan, manifest_dir)
+    encoded_count: int = sum(1 for result in results if result.status == "encoded")
+    skipped_count: int = sum(1 for result in results if result.status == "skipped")
+    source_bytes: int = sum(result.source_size_bytes for result in results)
+    target_bytes: int = sum(result.target_size_bytes for result in results)
+    saved_fraction: float = 1.0 - (target_bytes / source_bytes) if source_bytes > 0 else 0.0
+    print(f"Encoded: {encoded_count}; skipped valid existing: {skipped_count}")
+    print(f"Video bytes: {source_bytes} -> {target_bytes} ({saved_fraction:.1%} saved)")

--- a/simplecv/apis/view_exoego.py
+++ b/simplecv/apis/view_exoego.py
@@ -337,8 +337,8 @@ def log_mano_batch(
 
         mano_root_path: Path = mano_parent_log_path / "mano"
         mano_layers = [
-            MANOLayerNP(side="right", betas=mano_stack.betas),
-            MANOLayerNP(side="left", betas=mano_stack.betas),
+            MANOLayerNP(side="right", betas=mano_stack.betas, use_pca=mano_stack.use_pca),
+            MANOLayerNP(side="left", betas=mano_stack.betas, use_pca=mano_stack.use_pca),
         ]
         mano_so3: Float32[ndarray, "n_frames n_hands=2 48"] = mano_stack.so3
         mano_trans: Float32[ndarray, "n_frames n_hands=2 3"] = mano_stack.trans
@@ -759,6 +759,33 @@ def _choose_shortest_timeline_by_duration(
     return timelines[min_idx]
 
 
+def _video_stream_timestamps_for_logging(
+    exoego_sequence: BaseExoEgoSequence,
+    *,
+    log_ego: bool,
+    log_exo: bool,
+) -> list[Int[ndarray, "n_frames"]]:
+    """Return only ego/exo video stream timestamps, excluding label-only streams."""
+    timestamp_list: list[Int[ndarray, "n_frames"]] = []
+    ego_sequence: BaseEgoSequence | None = exoego_sequence.ego_sequence
+    if log_ego and ego_sequence is not None:
+        for stream_name in ego_sequence.ego_video_names:
+            stream_timestamps: Int[ndarray, "n_frames"] | None = exoego_sequence.stream_timestamps_ns.get(
+                f"ego/{stream_name}"
+            )
+            if stream_timestamps is not None:
+                timestamp_list.append(stream_timestamps)
+
+    exo_sequence: BaseExoSequence | None = exoego_sequence.exo_sequence
+    if log_exo and exo_sequence is not None:
+        for stream_name in exo_sequence.exo_video_names:
+            stream_timestamps = exoego_sequence.stream_timestamps_ns.get(f"exo/{stream_name}")
+            if stream_timestamps is not None:
+                timestamp_list.append(stream_timestamps)
+
+    return timestamp_list
+
+
 def setup_scene(
     exoego_sequence: BaseExoEgoSequence,
     *,
@@ -843,6 +870,52 @@ def setup_scene(
         )
         ego_video_log_path_list: list[Path] = []
 
+        def _log_ego_cameras(shortest_ego_timestamp: Int[ndarray, "n_frames"]) -> None:
+            ego_cam_dict: dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]] = cast(
+                dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]], ego_sequence.ego_cam_dict
+            )
+            for cam_name, ego_cam_param_list in ego_cam_dict.items():
+                if not ego_cam_param_list:
+                    continue
+                n_frames_cam: int = min(len(ego_cam_param_list), len(shortest_ego_timestamp))
+                if n_frames_cam <= 0:
+                    continue
+                trimmed_cam_params: list[PinholeParameters | Fisheye62Parameters] = ego_cam_param_list[:n_frames_cam]
+                # We assume that all cameras share intrinsics across frames
+                first_cam: PinholeParameters | Fisheye62Parameters = trimmed_cam_params[0]
+                cam_log_path: Path = parent_log_path / "ego" / str(cam_name)
+                pinhole_log_path: Path = cam_log_path / "pinhole"
+                rr.log(
+                    f"{pinhole_log_path}",
+                    PinholeWithDistortion.from_camera(
+                        first_cam,
+                        image_plane_distance=ego_sequence.image_plane_distance,
+                        include_distortion=True,
+                    ),
+                    static=True,
+                    recording=recording,
+                )
+                batch_world_t_cam: Float[ndarray, "n_frames 3"] = np.array(
+                    [ego_cam_param.extrinsics.world_t_cam for ego_cam_param in trimmed_cam_params]
+                )
+                batch_world_R_cam: Float[ndarray, "n_frames 3 3"] = np.array(
+                    [ego_cam_param.extrinsics.world_R_cam for ego_cam_param in trimmed_cam_params]
+                )
+                # camera extrinsics, there's no from_parent=True so need to send as world_x_cam
+                rr.send_columns(
+                    f"{cam_log_path}",
+                    indexes=[
+                        rr.TimeColumn(timeline, duration=1e-9 * shortest_ego_timestamp[0 : len(batch_world_t_cam)])
+                    ],
+                    columns=[
+                        *rr.Transform3D.columns(
+                            translation=rearrange(batch_world_t_cam, "f d -> (f) d"),
+                            mat3x3=rearrange(batch_world_R_cam, "f r c -> (f) r c"),
+                        ),
+                    ],
+                    recording=recording,
+                )
+
         for stream_name, video_file in zip(ego_video_names, ego_video_files, strict=True):
             cam_log_path: Path = parent_log_path / "ego" / stream_name
             ego_video_log_path: Path = cam_log_path / "pinhole" / "video"
@@ -862,50 +935,10 @@ def setup_scene(
             ego_timestamp_list.append(ego_timestamps_ns)
         ego_video_log_paths = ego_video_log_path_list
 
-        # log the ego cameras and their trajectories
-        shortest_ego_timestamp: Int[ndarray, "n_frames"] = _choose_shortest_timeline_by_duration(ego_timestamp_list)
-        ego_cam_dict: dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]] = cast(
-            dict[CamNameType, list[PinholeParameters | Fisheye62Parameters]], ego_sequence.ego_cam_dict
-        )
-        for cam_name, ego_cam_param_list in ego_cam_dict.items():
-            if not ego_cam_param_list:
-                continue
-            n_frames_cam: int = min(len(ego_cam_param_list), len(shortest_ego_timestamp))
-            if n_frames_cam <= 0:
-                continue
-            trimmed_cam_params: list[PinholeParameters | Fisheye62Parameters] = ego_cam_param_list[:n_frames_cam]
-            # We assume that all cameras share intrinsics across frames
-            first_cam: PinholeParameters | Fisheye62Parameters = trimmed_cam_params[0]
-            cam_log_path: Path = parent_log_path / "ego" / str(cam_name)
-            pinhole_log_path: Path = cam_log_path / "pinhole"
-            rr.log(
-                f"{pinhole_log_path}",
-                PinholeWithDistortion.from_camera(
-                    first_cam,
-                    image_plane_distance=ego_sequence.image_plane_distance,
-                    include_distortion=True,
-                ),
-                static=True,
-                recording=recording,
-            )
-            batch_world_t_cam: Float[ndarray, "n_frames 3"] = np.array(
-                [ego_cam_param.extrinsics.world_t_cam for ego_cam_param in trimmed_cam_params]
-            )
-            batch_world_R_cam: Float[ndarray, "n_frames 3 3"] = np.array(
-                [ego_cam_param.extrinsics.world_R_cam for ego_cam_param in trimmed_cam_params]
-            )
-            # camera extrinsics, there's no from_parent=True so need to send as world_x_cam
-            rr.send_columns(
-                f"{cam_log_path}",
-                indexes=[rr.TimeColumn(timeline, duration=1e-9 * shortest_ego_timestamp[0 : len(batch_world_t_cam)])],
-                columns=[
-                    *rr.Transform3D.columns(
-                        translation=rearrange(batch_world_t_cam, "f d -> (f) d"),
-                        mat3x3=rearrange(batch_world_R_cam, "f r c -> (f) r c"),
-                    ),
-                ],
-                recording=recording,
-            )
+        # Camera trajectories are logged after video ingestion so their time
+        # range is clipped to the frames the demuxer actually accepted.
+        if ego_timestamp_list:
+            _log_ego_cameras(_choose_shortest_timeline_by_duration(ego_timestamp_list))
 
     shortest_timestamp: Int[ndarray, "n_frames"] = _choose_shortest_timeline_by_duration(
         exo_timestamp_list + ego_timestamp_list
@@ -936,6 +969,23 @@ def visualize_exo_ego(exoego_sequence: BaseExoEgoSequence, config: VisualizeConf
     parent_log_path = Path("world")
     timeline: str = "video_time"
 
+    if config.log_labels:
+        video_timestamp_list: list[Int[ndarray, "n_frames"]] = _video_stream_timestamps_for_logging(
+            exoego_sequence,
+            log_ego=config.log_ego,
+            log_exo=config.log_exo,
+        )
+        label_fallback_timestamp: Int[ndarray, "n_frames"] = _choose_shortest_timeline_by_duration(video_timestamp_list)
+        log_exoego_batch(
+            exoego_sequence,
+            parent_log_path=parent_log_path,
+            timeline=timeline,
+            shortest_timestamp=label_fallback_timestamp,
+            log_ego=config.log_ego,
+            log_exo=config.log_exo,
+            log_mano=config.log_mano,
+        )
+
     scene_setup_result: SceneSetupResult = setup_scene(
         exoego_sequence,
         parent_log_path=parent_log_path,
@@ -944,7 +994,6 @@ def visualize_exo_ego(exoego_sequence: BaseExoEgoSequence, config: VisualizeConf
         log_exo=config.log_exo,
     )
     log_paths: LogPaths = scene_setup_result.log_paths
-    shortest_timestamp: Int[ndarray, "n_frames"] = scene_setup_result.shortest_timestamp
 
     if config.log_env_mesh:
         log_environment_mesh(exoego_sequence, parent_log_path)
@@ -974,17 +1023,6 @@ def visualize_exo_ego(exoego_sequence: BaseExoEgoSequence, config: VisualizeConf
         collapse_panels=True,
     )
     rr.send_blueprint(blueprint)
-
-    if config.log_labels:
-        log_exoego_batch(
-            exoego_sequence,
-            parent_log_path=parent_log_path,
-            timeline=timeline,
-            shortest_timestamp=shortest_timestamp,
-            log_ego=config.log_ego,
-            log_exo=config.log_exo,
-            log_mano=config.log_mano,
-        )
 
     print(f"Total time taken: {timer() - start_time:.2f} seconds")
 

--- a/simplecv/configs/exoego_dataset_configs.py
+++ b/simplecv/configs/exoego_dataset_configs.py
@@ -9,6 +9,7 @@ from simplecv.data.exoego.assembly101 import Assembly101Config
 from simplecv.data.exoego.base_exoego import BaseExoEgoDatasetConfig
 from simplecv.data.exoego.ego100k import Egocentric100KConfig
 from simplecv.data.exoego.ego_dex import EgoDexConfig
+from simplecv.data.exoego.epfl_smart_kitchen import EpflSmartKitchenConfig
 from simplecv.data.exoego.hocap import HocapConfig
 from simplecv.data.exoego.hot3d import Hot3dConfig
 from simplecv.data.exoego.robocap import RobocapConfig
@@ -20,6 +21,7 @@ dataset_defaults = {
     "aria-gen2": AriaGen2PilotConfig(),
     "assembly101": Assembly101Config(),
     "ego100k": Egocentric100KConfig(),
+    "epfl-smart-kitchen": EpflSmartKitchenConfig(),
     "hocap": HocapConfig(),
     "ego-dex": EgoDexConfig(),
     "hot3d": Hot3dConfig(),

--- a/simplecv/data/ego/epfl_smart_kitchen_ego.py
+++ b/simplecv/data/ego/epfl_smart_kitchen_ego.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jaxtyping import Float32
+from numpy import ndarray
+from rerun.components.view_coordinates import ViewCoordinates
+
+from simplecv.camera_parameters import BrownConradyDistortion, Extrinsics, Intrinsics, PinholeParameters
+from simplecv.data.ego.base_ego import BaseEgoSequence, EgoData
+from simplecv.data.exoego.epfl_smart_kitchen import (
+    EPFL_EGO_CAMERA_NAME,
+    _camera_size,
+    _distortion_from_entry,
+    _matrix3,
+    load_camera_matrix,
+    load_hololens_world_to_camera_poses,
+    video_path_for_camera,
+)
+
+if TYPE_CHECKING:
+    from simplecv.data.exoego.epfl_smart_kitchen import EpflSmartKitchenConfig
+else:
+    from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig as EpflSmartKitchenConfig
+
+
+class EpflSmartKitchenEgoSequence(BaseEgoSequence[EpflSmartKitchenConfig]):
+    """HoloLens ego stream for EPFL-Smart-Kitchen."""
+
+    def load_video_paths(self) -> list[Path]:
+        video_path: Path = video_path_for_camera(self.config, EPFL_EGO_CAMERA_NAME)
+        if not video_path.exists():
+            raise FileNotFoundError(f"EPFL HoloLens RGB video not found: {video_path}")
+        return [video_path]
+
+    def load_ego_cams(self) -> dict[str, list[PinholeParameters]]:
+        camera_matrix: dict[str, dict] = load_camera_matrix(self.config)
+        if EPFL_EGO_CAMERA_NAME not in camera_matrix:
+            raise KeyError(f"EPFL camera matrix is missing {EPFL_EGO_CAMERA_NAME!r}")
+        entry: dict = camera_matrix[EPFL_EGO_CAMERA_NAME]
+        video_path: Path = video_path_for_camera(self.config, EPFL_EGO_CAMERA_NAME)
+        image_size: tuple[int, int] = _camera_size(entry, video_path)
+        width: int = image_size[0]
+        height: int = image_size[1]
+        k_matrix: Float32[ndarray, "3 3"] = _matrix3(entry["K"], field_name=f"{EPFL_EGO_CAMERA_NAME}.K")
+        intrinsics: Intrinsics = Intrinsics.from_k_matrix(
+            camera_conventions="RDF",
+            k_matrix=k_matrix,
+            width=width,
+            height=height,
+        )
+        distortion: BrownConradyDistortion | None = _distortion_from_entry(EPFL_EGO_CAMERA_NAME, entry)
+        cam_T_world_list: list[Float32[ndarray, "4 4"]] = load_hololens_world_to_camera_poses(self.config)
+        camera_list: list[PinholeParameters] = []
+        for cam_T_world in cam_T_world_list:
+            extrinsics: Extrinsics = Extrinsics(
+                cam_R_world=cam_T_world[:3, :3],
+                cam_t_world=cam_T_world[:3, 3],
+            )
+            camera_params: PinholeParameters = PinholeParameters(
+                name=EPFL_EGO_CAMERA_NAME,
+                intrinsics=intrinsics,
+                extrinsics=extrinsics,
+                distortion=distortion,
+            )
+            camera_list.append(camera_params)
+        return {EPFL_EGO_CAMERA_NAME: camera_list}
+
+    def align_cams_and_videos(
+        self,
+        video_path_list: list[Path],
+        ego_cam_dict: dict[str, list[PinholeParameters]],
+    ) -> tuple[dict[str, list[PinholeParameters]], dict[str, Path]]:
+        if len(video_path_list) != 1:
+            raise ValueError(f"Expected one EPFL HoloLens video, got {len(video_path_list)}")
+        if set(ego_cam_dict) != {EPFL_EGO_CAMERA_NAME}:
+            raise ValueError(f"Expected one EPFL HoloLens camera, got {set(ego_cam_dict)}")
+        return ego_cam_dict, {EPFL_EGO_CAMERA_NAME: video_path_list[0]}
+
+    def __getitem__(self, idx: int) -> EgoData:
+        bgr_list = self.ego_video_readers[idx]
+        camera_list: list[PinholeParameters] = self.ego_cam_dict[EPFL_EGO_CAMERA_NAME]
+        camera_idx: int = min(idx, len(camera_list) - 1)
+        if idx >= len(camera_list) and not getattr(self, "_warned_pose_clamp", False):
+            warnings.warn(
+                f"EPFL HoloLens camera poses have {len(camera_list)} entries but frame {idx} was requested; "
+                "reusing the final pose for trailing video frames.",
+                stacklevel=2,
+            )
+            self._warned_pose_clamp = True
+        return EgoData(cam_params_list=[camera_list[camera_idx]], bgr_list=bgr_list)
+
+    @property
+    def image_plane_distance(self) -> int | float:
+        return 0.1
+
+    @property
+    def world_coordinate_system(self) -> ViewCoordinates:
+        return ViewCoordinates.RIGHT_HAND_Z_UP

--- a/simplecv/data/exo/base_exo.py
+++ b/simplecv/data/exo/base_exo.py
@@ -23,6 +23,7 @@ class ManoStack:
     - betas: One shape vector shared across frames and hands.
     - so3: Axis-angle pose coefficients (48 = 16 joints x 3) per frame/hand.
     - trans: Global translation per frame/hand.
+    - use_pca: Whether the final 45 pose coefficients are MANO PCA coefficients.
 
     Notes
     - Hand index convention: 0 = right, 1 = left.
@@ -32,6 +33,7 @@ class ManoStack:
     betas: Float32[ndarray, "10"]
     so3: Float32[ndarray, "n_frames n_hands=2 48"]
     trans: Float32[ndarray, "n_frames n_hands=2 3"]
+    use_pca: bool = True
 
 
 @dataclass

--- a/simplecv/data/exo/epfl_smart_kitchen_exo.py
+++ b/simplecv/data/exo/epfl_smart_kitchen_exo.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jaxtyping import Float32
+from numpy import ndarray
+
+from simplecv.camera_parameters import PinholeParameters
+from simplecv.data.exo.base_exo import BaseExoSequence, ExoData
+from simplecv.data.exoego.epfl_smart_kitchen import (
+    EPFL_EXO_CAMERA_NAMES,
+    _matrix4,
+    _pinhole_from_entry,
+    load_camera_matrix,
+    video_path_for_camera,
+)
+
+if TYPE_CHECKING:
+    from simplecv.data.exoego.epfl_smart_kitchen import EpflSmartKitchenConfig
+else:
+    from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig as EpflSmartKitchenConfig
+
+
+class EpflSmartKitchenExoSequence(BaseExoSequence[EpflSmartKitchenConfig]):
+    """Static exocentric RGB streams for EPFL-Smart-Kitchen."""
+
+    def load_video_paths(self) -> list[Path]:
+        video_paths: list[Path] = []
+        for camera_name in self.config.exo_camera_names:
+            if camera_name not in EPFL_EXO_CAMERA_NAMES:
+                raise ValueError(f"Unknown EPFL exo camera name: {camera_name}")
+            video_path: Path = video_path_for_camera(self.config, camera_name)
+            if not video_path.exists():
+                raise FileNotFoundError(f"EPFL exo RGB video not found for {camera_name}: {video_path}")
+            video_paths.append(video_path)
+        return video_paths
+
+    def load_exo_cams(self) -> list[PinholeParameters | None]:
+        camera_matrix: dict[str, dict] = load_camera_matrix(self.config)
+        cameras: list[PinholeParameters | None] = []
+        warned_word2cam: bool = False
+        for camera_name in self.config.exo_camera_names:
+            if camera_name not in camera_matrix:
+                raise KeyError(f"EPFL camera matrix is missing {camera_name!r}")
+            entry: dict = camera_matrix[camera_name]
+            cam_T_world_raw: object | None = entry.get("world2cam", entry.get("word2cam"))
+            if cam_T_world_raw is None:
+                raise KeyError(f"EPFL camera matrix entry {camera_name!r} is missing world2cam")
+            if "world2cam" not in entry and "word2cam" in entry and not warned_word2cam:
+                warnings.warn(
+                    "EPFL camera_matrix.json uses the upstream 'word2cam' key; treating it as world2cam.",
+                    stacklevel=2,
+                )
+                warned_word2cam = True
+            cam_T_world: Float32[ndarray, "4 4"] = _matrix4(cam_T_world_raw, field_name=f"{camera_name}.world2cam")
+            video_path: Path = video_path_for_camera(self.config, camera_name)
+            cameras.append(
+                _pinhole_from_entry(
+                    camera_name=camera_name,
+                    entry=entry,
+                    video_path=video_path,
+                    cam_T_world=cam_T_world,
+                )
+            )
+        return cameras
+
+    def __getitem__(self, idx: int) -> ExoData:
+        bgr_list = self.exo_video_readers[idx]
+        return ExoData(
+            cam_params_list=[cam for cam in self.exo_cam_list if cam is not None],
+            bgr_list=bgr_list,
+            xyz=None,
+            uv_dict=None,
+        )
+
+    @property
+    def image_plane_distance(self) -> int | float:
+        return 0.25

--- a/simplecv/data/exoego/epfl_smart_kitchen.py
+++ b/simplecv/data/exoego/epfl_smart_kitchen.py
@@ -1,0 +1,683 @@
+from __future__ import annotations
+
+import ast
+import csv
+import json
+import warnings
+from collections.abc import Generator
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Literal
+
+import cv2
+import numpy as np
+from jaxtyping import Float32, Int
+from natsort import natsorted
+from numpy import ndarray
+from rerun.components.view_coordinates import ViewCoordinates
+
+from simplecv.camera_parameters import BrownConradyDistortion, Extrinsics, Intrinsics, PinholeParameters
+from simplecv.data.ego.base_ego import BaseEgoSequence
+from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample
+from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
+from simplecv.data.exoego.sequence_identity import SequenceIdentity
+from simplecv.data.skeleton.coco_133 import LEFT_HAND_IDX, RIGHT_HAND_IDX
+
+EpflExoCameraName = Literal[
+    "output0",
+    "Aoutput0",
+    "Aoutput1",
+    "Aoutput2",
+    "Aoutput3",
+    "Boutput0",
+    "Boutput1",
+    "Boutput2",
+    "Boutput3",
+]
+
+EPFL_EXO_CAMERA_NAMES: tuple[EpflExoCameraName, ...] = (
+    "output0",
+    "Aoutput0",
+    "Aoutput1",
+    "Aoutput2",
+    "Aoutput3",
+    "Boutput0",
+    "Boutput1",
+    "Boutput2",
+    "Boutput3",
+)
+EPFL_EGO_CAMERA_NAME: str = "hololens"
+
+
+@dataclass
+class EpflSmartKitchenConfig(BaseExoEgoDatasetConfig):
+    """EPFL-Smart-Kitchen dataset config."""
+
+    _target: type = field(default_factory=lambda: EpflSmartKitchenSequence)
+    """Target class to instantiate."""
+    root_directory: Path = Path("/mnt/8tb/data/epfl-smart-kitchen-av1")
+    """Directory containing the AV1-transcoded EPFL public release layout."""
+    split: Literal["train", "test"] = "train"
+    """Dataset split containing the selected session."""
+    participant_id: str = "YH2002"
+    """EPFL participant identifier, preserved exactly from the public release."""
+    session_name: str = "2023_12_04_10_15_23"
+    """EPFL session directory name, preserved exactly from the public release."""
+    exo_camera_names: tuple[EpflExoCameraName, ...] = EPFL_EXO_CAMERA_NAMES
+    """Exocentric RGB camera names to load."""
+
+
+def video_session_dir(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the EPFL public-video session directory for ``cfg``."""
+    return cfg.root_directory / "Public_release_videos" / cfg.split / cfg.participant_id / cfg.session_name
+
+
+def pose_session_dir(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the EPFL public-pose session directory for ``cfg``."""
+    return cfg.root_directory / "Public_release_pose" / cfg.split / cfg.participant_id / cfg.session_name
+
+
+def body_pose_path(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the EPFL SMPL-derived body keypoint CSV path."""
+    return pose_session_dir(cfg) / "pose_3d" / "pose3d_smpl.csv"
+
+
+def hand_pose_path(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the EPFL MANO-derived hand keypoint CSV path."""
+    return pose_session_dir(cfg) / "pose_3d" / "pose3d_mano.csv"
+
+
+def camera_matrix_path(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the per-session camera calibration JSON path."""
+    return video_session_dir(cfg) / "meta_data" / "camera_matrix.json"
+
+
+def holo_pose_path(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the per-session HoloLens metadata CSV path."""
+    return video_session_dir(cfg) / "meta_data" / "holo_data_wpose.csv"
+
+
+def rgb_timestamps_path(cfg: EpflSmartKitchenConfig) -> Path:
+    """Return the per-session RGB timestamp metadata path."""
+    return video_session_dir(cfg) / "meta_data" / "timestamps.txt"
+
+
+def video_path_for_camera(cfg: EpflSmartKitchenConfig, camera_name: str) -> Path:
+    """Return the RGB MP4 path for an EPFL camera."""
+    video_path: Path = video_session_dir(cfg) / "videos" / f"{camera_name}.mp4"
+    return video_path
+
+
+def load_camera_matrix(cfg: EpflSmartKitchenConfig) -> dict[str, dict]:
+    """Load EPFL ``camera_matrix.json``."""
+    path: Path = camera_matrix_path(cfg)
+    if not path.exists():
+        raise FileNotFoundError(f"EPFL camera calibration not found: {path}")
+    data: dict[str, dict] = json.loads(path.read_text())
+    return data
+
+
+def _matrix4(value: object, *, field_name: str) -> ndarray:
+    matrix: ndarray = np.asarray(value, dtype=np.float32)
+    if matrix.shape == (4, 4):
+        return matrix
+    if matrix.size == 16:
+        return matrix.reshape(4, 4)
+    raise ValueError(f"{field_name} must be a 4x4 transform, got shape {matrix.shape}")
+
+
+def _matrix3(value: object, *, field_name: str) -> ndarray:
+    matrix: ndarray = np.asarray(value, dtype=np.float32)
+    if matrix.shape == (3, 3):
+        return matrix
+    if matrix.size == 9:
+        return matrix.reshape(3, 3)
+    raise ValueError(f"{field_name} must be a 3x3 matrix, got shape {matrix.shape}")
+
+
+def _video_size(video_path: Path) -> tuple[int, int]:
+    capture: cv2.VideoCapture = cv2.VideoCapture(str(video_path))
+    try:
+        width: int = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height: int = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    finally:
+        capture.release()
+    if width <= 0 or height <= 0:
+        raise ValueError(f"Could not read video dimensions from {video_path}")
+    return width, height
+
+
+def _camera_size(entry: dict, video_path: Path) -> tuple[int, int]:
+    width_raw: object | None = entry.get("width")
+    height_raw: object | None = entry.get("height")
+    if width_raw is not None and height_raw is not None:
+        return int(width_raw), int(height_raw)
+    return _video_size(video_path)
+
+
+def _distortion_from_entry(camera_name: str, entry: dict) -> BrownConradyDistortion | None:
+    coeffs_raw: object | None = entry.get("dist")
+    if coeffs_raw is None:
+        return None
+    coeffs: list[float] = [float(value) for value in np.asarray(coeffs_raw, dtype=np.float32).reshape(-1)]
+    if len(coeffs) == 0:
+        return None
+    if len(coeffs) not in {4, 5, 8, 12, 14}:
+        warnings.warn(
+            f"Unsupported EPFL distortion coefficient count for {camera_name}: {len(coeffs)}; using pinhole fallback.",
+            stacklevel=2,
+        )
+        return None
+    padded: list[float] = coeffs + [0.0] * (14 - len(coeffs))
+    return BrownConradyDistortion(
+        k1=padded[0],
+        k2=padded[1],
+        p1=padded[2],
+        p2=padded[3],
+        k3=padded[4],
+        k4=padded[5],
+        k5=padded[6],
+        k6=padded[7],
+        s1=padded[8],
+        s2=padded[9],
+        s3=padded[10],
+        s4=padded[11],
+        tau_x=padded[12],
+        tau_y=padded[13],
+    )
+
+
+def _pinhole_from_entry(
+    *,
+    camera_name: str,
+    entry: dict,
+    video_path: Path,
+    cam_T_world: ndarray,
+) -> PinholeParameters:
+    k_matrix: ndarray = _matrix3(entry["K"], field_name=f"{camera_name}.K")
+    width, height = _camera_size(entry, video_path)
+    intrinsics: Intrinsics = Intrinsics.from_k_matrix(
+        camera_conventions="RDF",
+        k_matrix=k_matrix,
+        width=width,
+        height=height,
+    )
+    extrinsics: Extrinsics = Extrinsics(
+        cam_R_world=cam_T_world[:3, :3],
+        cam_t_world=cam_T_world[:3, 3],
+    )
+    return PinholeParameters(
+        name=camera_name,
+        intrinsics=intrinsics,
+        extrinsics=extrinsics,
+        distortion=_distortion_from_entry(camera_name, entry),
+    )
+
+
+def load_hololens_world_to_camera_poses(cfg: EpflSmartKitchenConfig) -> list[ndarray]:
+    """Load per-frame HoloLens world-to-camera transforms from ``holo_data_wpose.csv``."""
+    path: Path = holo_pose_path(cfg)
+    if not path.exists():
+        raise FileNotFoundError(f"EPFL HoloLens pose CSV not found: {path}")
+
+    transforms_raw: list[Float32[ndarray, "4 4"] | None] = []
+    missing_count: int = 0
+    with path.open(newline="") as file:
+        reader: csv.DictReader = csv.DictReader(file)
+        if reader.fieldnames is None or "world2holo" not in reader.fieldnames:
+            raise ValueError(f"EPFL HoloLens pose CSV must contain a world2holo column: {path}")
+        for row in reader:
+            text: str = row["world2holo"].strip()
+            value: object = json.loads(text)
+            if value == []:
+                transforms_raw.append(None)
+                missing_count += 1
+                continue
+            transforms_raw.append(_matrix4(value, field_name="world2holo"))
+    if not transforms_raw:
+        raise ValueError(f"EPFL HoloLens pose CSV contains no poses: {path}")
+
+    first_valid: Float32[ndarray, "4 4"] | None = next(
+        (transform for transform in transforms_raw if transform is not None),
+        None,
+    )
+    if first_valid is None:
+        raise ValueError(f"EPFL HoloLens pose CSV contains no valid world2holo transforms: {path}")
+    if missing_count > 0:
+        warnings.warn(
+            f"EPFL HoloLens pose CSV has missing {missing_count} HoloLens world2holo transforms; "
+            "carrying the previous valid pose when available and the first valid pose for leading gaps.",
+            stacklevel=2,
+        )
+
+    transforms: list[ndarray] = []
+    last_valid: Float32[ndarray, "4 4"] | None = None
+    for transform in transforms_raw:
+        if transform is None:
+            fallback: Float32[ndarray, "4 4"] = last_valid if last_valid is not None else first_valid
+            transforms.append(fallback.copy())
+        else:
+            transforms.append(transform)
+            last_valid = transform
+    return transforms
+
+
+def load_rgb_timestamps_ns(cfg: EpflSmartKitchenConfig) -> Int[ndarray, "n_frames"]:
+    """Load EPFL RGB frame timestamps from microseconds and normalize to nanoseconds."""
+    path: Path = rgb_timestamps_path(cfg)
+    if not path.exists():
+        raise FileNotFoundError(f"EPFL RGB timestamp metadata not found: {path}")
+    timestamps_us: Int[ndarray, "n_frames"] = np.loadtxt(path, dtype=np.int64, ndmin=1)
+    if timestamps_us.size == 0:
+        raise ValueError(f"EPFL RGB timestamp metadata contains no rows: {path}")
+    timestamps_us = timestamps_us.reshape(-1)
+    timestamps_ns: Int[ndarray, "n_frames"] = ((timestamps_us - timestamps_us[0]) * np.int64(1000)).astype(np.int64)
+    return timestamps_ns
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"EPFL pose CSV not found: {path}")
+    with path.open(newline="") as file:
+        reader: csv.DictReader = csv.DictReader(file)
+        if reader.fieldnames is None:
+            raise ValueError(f"EPFL pose CSV is missing a header row: {path}")
+        rows: list[dict[str, str]] = [dict(row) for row in reader]
+    if not rows:
+        raise ValueError(f"EPFL pose CSV contains no rows: {path}")
+    return rows
+
+
+class _NonFiniteLiteralTransformer(ast.NodeTransformer):
+    """Allow EPFL CSV cells to contain bare NaN/Infinity tokens."""
+
+    _CONSTANTS: dict[str, float] = {
+        "NaN": float("nan"),
+        "nan": float("nan"),
+        "Infinity": float("inf"),
+        "inf": float("inf"),
+    }
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if node.id not in self._CONSTANTS:
+            raise ValueError(f"Unsupported numeric token in EPFL CSV cell: {node.id}")
+        return ast.copy_location(ast.Constant(value=self._CONSTANTS[node.id]), node)
+
+
+def _parse_numeric_cell(value: str) -> ndarray:
+    text: str = value.strip()
+    expression: ast.Expression = ast.parse(text, mode="eval")
+    transformed_expression: ast.Expression = _NonFiniteLiteralTransformer().visit(expression)
+    ast.fix_missing_locations(transformed_expression)
+    parsed: object = ast.literal_eval(transformed_expression)
+    array: ndarray = np.asarray(parsed, dtype=np.float32)
+    return array
+
+
+def _parse_vector_cell(value: str, *, expected_len: int | None = None, field_name: str) -> ndarray:
+    vector: ndarray = _parse_numeric_cell(value).reshape(-1).astype(np.float32, copy=False)
+    if expected_len is not None and vector.shape[0] != expected_len:
+        raise ValueError(f"{field_name} must contain {expected_len} values, got {vector.shape[0]}")
+    return vector
+
+
+def _parse_keypoints(rows: list[dict[str, str]], *, num_keypoints: int, path: Path) -> ndarray:
+    keypoints: list[ndarray] = []
+    for row_idx, row in enumerate(rows):
+        if "kp3ds" not in row:
+            raise KeyError(f"EPFL pose CSV is missing kp3ds column: {path}")
+        frame_keypoints: ndarray = _parse_numeric_cell(row["kp3ds"]).astype(np.float32, copy=False)
+        if frame_keypoints.shape == (1, num_keypoints, 3):
+            frame_keypoints = frame_keypoints[0]
+        elif frame_keypoints.shape != (num_keypoints, 3):
+            if frame_keypoints.size != num_keypoints * 3:
+                raise ValueError(
+                    f"EPFL kp3ds row {row_idx} in {path} cannot reshape to ({num_keypoints}, 3); "
+                    f"got {frame_keypoints.shape}"
+                )
+            frame_keypoints = frame_keypoints.reshape(num_keypoints, 3)
+        keypoints.append(frame_keypoints)
+    return np.stack(keypoints).astype(np.float32, copy=False)
+
+
+def _parse_scalar(row: dict[str, str], key: str, *, default: float | None = None) -> float:
+    value: str | None = row.get(key)
+    if value is None or value == "":
+        if default is None:
+            raise KeyError(f"Missing scalar column {key}")
+        return default
+    return float(value)
+
+
+def _parse_confidences(
+    rows: list[dict[str, str]],
+    *,
+    num_keypoints: int,
+    mode: Literal["body", "hand"],
+    finite_mask: ndarray,
+) -> ndarray:
+    if "kp3ds_conf" not in rows[0]:
+        return finite_mask.astype(np.float32)
+
+    conf_list: list[ndarray] = [
+        _parse_vector_cell(row["kp3ds_conf"], expected_len=num_keypoints, field_name="kp3ds_conf")
+        for row in rows
+    ]
+    conf: ndarray = np.stack(conf_list).astype(np.float32, copy=False)
+    if mode == "body" and "l2_dist" in rows[0]:
+        empty_body_count: int = sum(1 for row in rows if row.get("l2_dist") in {None, ""})
+        if empty_body_count:
+            warnings.warn(
+                f"Found {empty_body_count} empty EPFL body l2 distance values; treating them as accepted confidence.",
+                stacklevel=2,
+            )
+        body_l2: ndarray = np.array(
+            [_parse_scalar(row, "l2_dist", default=0.0) for row in rows],
+            dtype=np.float32,
+        )
+        conf = conf * (body_l2 < np.float32(0.09))[:, np.newaxis]
+    if mode == "hand" and "l2_dist_left" in rows[0] and "l2_dist_right" in rows[0]:
+        empty_left_count: int = sum(1 for row in rows if row.get("l2_dist_left") in {None, ""})
+        empty_right_count: int = sum(1 for row in rows if row.get("l2_dist_right") in {None, ""})
+        empty_count: int = empty_left_count + empty_right_count
+        if empty_count:
+            warnings.warn(
+                f"Found {empty_count} empty EPFL hand l2 distance values; treating them as accepted confidence.",
+                stacklevel=2,
+            )
+        left_l2: ndarray = np.array([_parse_scalar(row, "l2_dist_left", default=0.0) for row in rows], dtype=np.float32)
+        right_l2: ndarray = np.array(
+            [_parse_scalar(row, "l2_dist_right", default=0.0) for row in rows],
+            dtype=np.float32,
+        )
+        conf[:, :21] = conf[:, :21] * (left_l2 < np.float32(0.06))[:, np.newaxis]
+        conf[:, 21:] = conf[:, 21:] * (right_l2 < np.float32(0.06))[:, np.newaxis]
+    conf = np.where(finite_mask, conf, np.float32(0.0)).astype(np.float32)
+    return conf
+
+
+def _apply_confidence_to_xyz(
+    xyz: Float32[ndarray, "num_frames num_kpts 3"],
+    conf: Float32[ndarray, "num_frames num_kpts"],
+) -> tuple[Float32[ndarray, "num_frames num_kpts 3"], Float32[ndarray, "num_frames num_kpts"]]:
+    xyz_out: ndarray = xyz.astype(np.float32, copy=True)
+    conf_out: ndarray = conf.astype(np.float32, copy=True)
+    finite_mask: ndarray = np.isfinite(xyz_out).all(axis=-1)
+    conf_out = np.where(finite_mask, conf_out, np.float32(0.0)).astype(np.float32)
+    xyz_out[conf_out <= np.float32(0.0)] = np.nan
+    return xyz_out, conf_out
+
+
+def _cell_from_aliases(row: dict[str, str], keys: tuple[str, ...], *, field_name: str) -> str:
+    for key in keys:
+        value: str | None = row.get(key)
+        if value is not None and value != "":
+            return value
+    raise KeyError(f"Missing EPFL column {field_name}; accepted aliases: {keys}")
+
+
+def _root_axis_angle(row: dict[str, str], keys: tuple[str, ...], *, field_name: str) -> ndarray:
+    root_raw: ndarray = _parse_numeric_cell(_cell_from_aliases(row, keys, field_name=field_name)).astype(
+        np.float32,
+        copy=False,
+    )
+    if root_raw.shape == (3,):
+        return root_raw
+    if root_raw.shape == (3, 3):
+        from scipy.spatial.transform import Rotation
+
+        return Rotation.from_matrix(root_raw).as_rotvec().astype(np.float32)
+    if root_raw.size == 9:
+        from scipy.spatial.transform import Rotation
+
+        return Rotation.from_matrix(root_raw.reshape(3, 3)).as_rotvec().astype(np.float32)
+    raise ValueError(f"{field_name} must be axis-angle length 3 or rotation matrix 3x3, got {root_raw.shape}")
+
+
+def _mano_pose_from_row(row: dict[str, str], *, side: Literal["left", "right"]) -> ndarray:
+    pose_key: str = f"{side}_poses"
+    pose: ndarray = _parse_vector_cell(row[pose_key], field_name=pose_key)
+    if pose.shape[0] == 48:
+        return pose.astype(np.float32, copy=False)
+    root: ndarray = _root_axis_angle(row, (f"{side}_Rh", f"{side}_RH"), field_name=f"{side}_Rh")
+    if pose.shape[0] == 45:
+        return np.concatenate([root, pose]).astype(np.float32, copy=False)
+    if pose.shape[0] < 45:
+        raise ValueError(
+            f"EPFL {pose_key} has {pose.shape[0]} coefficients, which looks like PCA coefficients. "
+            "SimpleCV does not yet validate EPFL MANO PCA expansion, so refusing to pad them as axis-angle."
+        )
+    raise ValueError(f"EPFL {pose_key} cannot be represented as MANO 48-vector; got {pose.shape[0]} values")
+
+
+def _load_mano_stack(hand_rows: list[dict[str, str]]) -> ManoStack:
+    required_column_aliases: dict[str, tuple[str, ...]] = {
+        "left_poses": ("left_poses",),
+        "right_poses": ("right_poses",),
+        "left_Rh": ("left_Rh", "left_RH"),
+        "right_Rh": ("right_Rh", "right_RH"),
+        "left_Th": ("left_Th", "left_TH"),
+        "right_Th": ("right_Th", "right_TH"),
+        "left_shapes": ("left_shapes",),
+        "right_shapes": ("right_shapes",),
+    }
+    missing_columns: list[str] = [
+        field_name
+        for field_name, aliases in required_column_aliases.items()
+        if not any(alias in hand_rows[0] for alias in aliases)
+    ]
+    if missing_columns:
+        raise KeyError(f"EPFL MANO parameter columns missing from pose3d_mano.csv: {missing_columns}")
+
+    left_shapes: ndarray = np.stack(
+        [
+            _parse_vector_cell(row["left_shapes"], expected_len=10, field_name="left_shapes")
+            for row in hand_rows
+        ]
+    ).astype(np.float32, copy=False)
+    right_shapes: ndarray = np.stack(
+        [
+            _parse_vector_cell(row["right_shapes"], expected_len=10, field_name="right_shapes")
+            for row in hand_rows
+        ]
+    ).astype(np.float32, copy=False)
+    shape_delta: float = float(np.nanmax(np.abs(left_shapes - right_shapes)))
+    if shape_delta > 1e-3:
+        warnings.warn(
+            f"EPFL left/right MANO shape parameters differ by {shape_delta:.6f}; using left shape.",
+            stacklevel=2,
+        )
+
+    num_frames: int = len(hand_rows)
+    so3: ndarray = np.zeros((num_frames, 2, 48), dtype=np.float32)
+    trans: ndarray = np.zeros((num_frames, 2, 3), dtype=np.float32)
+    for frame_idx, row in enumerate(hand_rows):
+        so3[frame_idx, 0] = _mano_pose_from_row(row, side="right")
+        so3[frame_idx, 1] = _mano_pose_from_row(row, side="left")
+        trans[frame_idx, 0] = _parse_vector_cell(
+            _cell_from_aliases(row, ("right_Th", "right_TH"), field_name="right_Th"),
+            expected_len=3,
+            field_name="right_Th",
+        )
+        trans[frame_idx, 1] = _parse_vector_cell(
+            _cell_from_aliases(row, ("left_Th", "left_TH"), field_name="left_Th"),
+            expected_len=3,
+            field_name="left_Th",
+        )
+
+    betas: ndarray = left_shapes[0].astype(np.float32, copy=False)
+    return ManoStack(betas=betas, so3=so3, trans=trans, use_pca=False)
+
+
+class EpflSmartKitchenSequence(BaseExoEgoSequence[EpflSmartKitchenConfig]):
+    """EPFL-Smart-Kitchen ExoEgo dataset adapter."""
+
+    _SPLITS: tuple[Literal["train", "test"], ...] = ("train", "test")
+
+    @classmethod
+    def sequence_identity_for_config(cls, cfg: EpflSmartKitchenConfig) -> SequenceIdentity:
+        return SequenceIdentity(
+            dataset="epfl-smart-kitchen",
+            parts=(cfg.split, cfg.participant_id, cfg.session_name),
+        )
+
+    def __getitem__(self, idx: int | None = None, ts_nano: np.timedelta64 | None = None) -> ExoEgoSample:
+        canonical_idx, ts_ns = self._resolve_canonical(idx=idx, ts_nano=ts_nano)
+        ego_cam_params_list, ego_bgr_list = self._sample_ego(ts_ns)
+        exo_cam_params_list, exo_bgr_list = self._sample_exo(ts_ns)
+        labels: ExoEgoLabels | None = self._sample_labels(canonical_idx, ts_ns)
+        return ExoEgoSample(
+            canonical_index=canonical_idx,
+            canonical_timestamp_ns=ts_ns,
+            ego_cam_params_list=ego_cam_params_list,
+            ego_bgr_list=ego_bgr_list,
+            exo_cam_params_list=exo_cam_params_list,
+            exo_bgr_list=exo_bgr_list,
+            labels=labels,
+        )
+
+    def _build_ego(self) -> BaseEgoSequence[EpflSmartKitchenConfig] | None:
+        from simplecv.data.ego.epfl_smart_kitchen_ego import EpflSmartKitchenEgoSequence
+
+        return EpflSmartKitchenEgoSequence(cfg=self.config)
+
+    def _build_exo(self) -> BaseExoSequence[EpflSmartKitchenConfig] | None:
+        from simplecv.data.exo.epfl_smart_kitchen_exo import EpflSmartKitchenExoSequence
+
+        return EpflSmartKitchenExoSequence(cfg=self.config)
+
+    def load_stream_timestamps_ns(self) -> dict[str, Int[ndarray, "n_frames"]]:
+        stream_ts: dict[str, Int[ndarray, "n_frames"]] = {}
+        self._ego_stream_names.clear()
+        self._exo_stream_names.clear()
+        rgb_timestamps_ns: Int[ndarray, "n_frames"] = load_rgb_timestamps_ns(self.config)
+
+        if self.ego_sequence is not None:
+            for name in self.ego_sequence.ego_video_names:
+                stream_name: str = f"ego/{name}"
+                stream_ts[stream_name] = rgb_timestamps_ns
+                self._ego_stream_names.append(stream_name)
+
+        if self.exo_sequence is not None:
+            for name in self.exo_sequence.exo_video_names:
+                stream_name = f"exo/{name}"
+                stream_ts[stream_name] = rgb_timestamps_ns
+                self._exo_stream_names.append(stream_name)
+
+        return stream_ts
+
+    def load_labels(self) -> ExoEgoLabels | None:
+        body_path: Path = body_pose_path(self.config)
+        hand_path: Path = hand_pose_path(self.config)
+        body_rows: list[dict[str, str]] = _read_csv_rows(body_path)
+        hand_rows: list[dict[str, str]] = _read_csv_rows(hand_path)
+        if len(body_rows) != len(hand_rows):
+            raise ValueError(
+                "EPFL body and hand label frame counts must match: "
+                f"{body_path} has {len(body_rows)}, {hand_path} has {len(hand_rows)}"
+            )
+
+        body_xyz_raw: Float32[ndarray, "num_frames body_kpts=17 3"] = _parse_keypoints(
+            body_rows,
+            num_keypoints=17,
+            path=body_path,
+        )
+        hand_xyz_raw: Float32[ndarray, "num_frames hand_kpts=42 3"] = _parse_keypoints(
+            hand_rows,
+            num_keypoints=42,
+            path=hand_path,
+        )
+        body_finite: ndarray = np.isfinite(body_xyz_raw).all(axis=-1)
+        hand_finite: ndarray = np.isfinite(hand_xyz_raw).all(axis=-1)
+        body_conf_raw: Float32[ndarray, "num_frames body_kpts=17"] = _parse_confidences(
+            body_rows,
+            num_keypoints=17,
+            mode="body",
+            finite_mask=body_finite,
+        )
+        hand_conf_raw: Float32[ndarray, "num_frames hand_kpts=42"] = _parse_confidences(
+            hand_rows,
+            num_keypoints=42,
+            mode="hand",
+            finite_mask=hand_finite,
+        )
+        body_xyz: Float32[ndarray, "num_frames body_kpts=17 3"]
+        body_conf: Float32[ndarray, "num_frames body_kpts=17"]
+        body_confidence_result: tuple[
+            Float32[ndarray, "num_frames body_kpts=17 3"],
+            Float32[ndarray, "num_frames body_kpts=17"],
+        ] = _apply_confidence_to_xyz(body_xyz_raw, body_conf_raw)
+        body_xyz = body_confidence_result[0]
+        body_conf = body_confidence_result[1]
+        hand_xyz: Float32[ndarray, "num_frames hand_kpts=42 3"]
+        hand_conf: Float32[ndarray, "num_frames hand_kpts=42"]
+        hand_confidence_result: tuple[
+            Float32[ndarray, "num_frames hand_kpts=42 3"],
+            Float32[ndarray, "num_frames hand_kpts=42"],
+        ] = _apply_confidence_to_xyz(hand_xyz_raw, hand_conf_raw)
+        hand_xyz = hand_confidence_result[0]
+        hand_conf = hand_confidence_result[1]
+
+        num_frames: int = int(body_xyz.shape[0])
+        label_timestamps_ns: Int[ndarray, "num_frames"] = load_rgb_timestamps_ns(self.config)
+        if label_timestamps_ns.shape[0] != num_frames:
+            raise ValueError(
+                "EPFL label frame count must match RGB timestamp count: "
+                f"labels have {num_frames} frames, timestamps have {label_timestamps_ns.shape[0]} frames."
+            )
+        xyzc_stack: Float32[ndarray, "num_frames coco_kpts=133 4"] = np.full(
+            (num_frames, 133, 4),
+            np.nan,
+            dtype=np.float32,
+        )
+        xyzc_stack[:, :, 3] = np.float32(0.0)
+        xyzc_stack[:, :17, :3] = body_xyz
+        xyzc_stack[:, :17, 3] = body_conf
+        xyzc_stack[:, LEFT_HAND_IDX, :3] = hand_xyz[:, :21]
+        xyzc_stack[:, LEFT_HAND_IDX, 3] = hand_conf[:, :21]
+        xyzc_stack[:, RIGHT_HAND_IDX, :3] = hand_xyz[:, 21:]
+        xyzc_stack[:, RIGHT_HAND_IDX, 3] = hand_conf[:, 21:]
+
+        mano_stack: ManoStack = _load_mano_stack(hand_rows)
+        return ExoEgoLabels(xyzc_stack=xyzc_stack, timestamps_ns=label_timestamps_ns, mano_stack=mano_stack)
+
+    @classmethod
+    def iter_episode_sequences(
+        cls, cfg: EpflSmartKitchenConfig
+    ) -> Generator["EpflSmartKitchenSequence", None, None]:
+        for split, participant_id, session_name in cls._episode_specs(cfg):
+            episode_cfg: EpflSmartKitchenConfig = replace(
+                cfg,
+                split=split,
+                participant_id=participant_id,
+                session_name=session_name,
+            )
+            yield cls(episode_cfg)
+
+    @classmethod
+    def num_sequences_for_config(cls, cfg: EpflSmartKitchenConfig) -> int:
+        return len(cls._episode_specs(cfg))
+
+    @classmethod
+    def _episode_specs(cls, cfg: EpflSmartKitchenConfig) -> list[tuple[Literal["train", "test"], str, str]]:
+        pose_root: Path = cfg.root_directory / "Public_release_pose"
+        video_root: Path = cfg.root_directory / "Public_release_videos"
+        specs: list[tuple[Literal["train", "test"], str, str]] = []
+        for split in cls._SPLITS:
+            split_dir: Path = pose_root / split
+            if not split_dir.exists():
+                continue
+            participant_dirs: list[Path] = natsorted([path for path in split_dir.iterdir() if path.is_dir()])
+            for participant_dir in participant_dirs:
+                session_dirs: list[Path] = natsorted([path for path in participant_dir.iterdir() if path.is_dir()])
+                for session_dir in session_dirs:
+                    video_dir: Path = video_root / split / participant_dir.name / session_dir.name
+                    if not video_dir.exists():
+                        continue
+                    specs.append((split, participant_dir.name, session_dir.name))
+        return specs
+
+    @property
+    def world_coordinate_system(self) -> ViewCoordinates:
+        return ViewCoordinates.RIGHT_HAND_Z_UP

--- a/simplecv/data/exoego/hocap.py
+++ b/simplecv/data/exoego/hocap.py
@@ -69,6 +69,7 @@ class HocapSequence(BaseExoEgoSequence[HocapConfig]):
                     betas=labels.mano_stack.betas,
                     so3=labels.mano_stack.so3[label_idx : label_idx + 1],
                     trans=labels.mano_stack.trans[label_idx : label_idx + 1],
+                    use_pca=labels.mano_stack.use_pca,
                 )
             timestamps_ns = labels.timestamps_ns
             labels = ExoEgoLabels(

--- a/simplecv/ops/mano/mano_np.py
+++ b/simplecv/ops/mano/mano_np.py
@@ -257,7 +257,11 @@ class MANOLayerNP:
     """NumPy implementation mirroring MANOLayerTorch's interface (meters output)."""
 
     def __init__(
-        self, side: Literal["left", "right"], betas: Float32[np.ndarray, "10"], mano_root_dir: Path | None = None
+        self,
+        side: Literal["left", "right"],
+        betas: Float32[np.ndarray, "10"],
+        mano_root_dir: Path | None = None,
+        use_pca: bool = True,
     ) -> None:
         if mano_root_dir is None:
             repo_root: Path = Path(__file__).resolve().parents[2]
@@ -291,12 +295,13 @@ class MANOLayerNP:
 
         self._side: Literal["left", "right"] = side
         self._betas: Float32[np.ndarray, "10"] = betas
+        self._use_pca: bool = use_pca
 
         self._mano_layer = ManoSimpleLayerNP(
             side=side,
             mano_root=mano_root_dir,
             ncomps=45,
-            use_pca=True,
+            use_pca=use_pca,
         )
 
         # Store faces

--- a/simplecv/rerun_custom_types.py
+++ b/simplecv/rerun_custom_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 import pyarrow as pa

--- a/simplecv/rerun_log_utils.py
+++ b/simplecv/rerun_log_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import sys
+import warnings
 from dataclasses import dataclass, field
 from fractions import Fraction
 from pathlib import Path
@@ -270,8 +271,8 @@ def log_video(
         timeline: Timeline name for frame timestamps.
         method: ``"video_stream"`` (default) demuxes encoded codec samples into
             ``rr.VideoStream``. ``"asset_video"`` embeds the whole MP4 blob via
-            ``rr.AssetVideo`` + ``rr.VideoFrameReference``; kept for validation
-            and as a fallback for codecs unsupported by ``rr.VideoStream``.
+            ``rr.AssetVideo`` + ``rr.VideoFrameReference``; callers must request
+            it explicitly.
         recording: Optional specific recording stream to log to.
 
     Returns:
@@ -300,7 +301,14 @@ def _log_asset_video(
 
     rr.log(str(video_log_path), video_asset, static=True, recording=recording)
 
-    frame_timestamps_ns: Int[ndarray, "num_frames"] = video_asset.read_frame_timestamps_nanos()
+    try:
+        frame_timestamps_ns: Int[ndarray, "num_frames"] = video_asset.read_frame_timestamps_nanos()
+    except RuntimeError as exc:
+        warnings.warn(
+            f"Rerun could not read AssetVideo frame timestamps ({exc}); falling back to PyAV demux timestamps.",
+            stacklevel=2,
+        )
+        frame_timestamps_ns = _read_frame_timestamps_nanos_pyav(video_source)
 
     rr.send_columns(
         f"{video_log_path}",
@@ -309,6 +317,28 @@ def _log_asset_video(
         recording=recording,
     )
     return frame_timestamps_ns
+
+
+def _read_frame_timestamps_nanos_pyav(video_source: Path | bytes) -> Int[ndarray, "num_frames"]:
+    """Read display timestamps by demuxing with PyAV when Rerun cannot inspect a codec."""
+    source_handle: io.BytesIO | str = io.BytesIO(video_source) if isinstance(video_source, bytes) else str(video_source)
+    container: av.container.InputContainer = av.open(source_handle, mode="r")
+    timestamps_ns: list[int] = []
+    try:
+        in_stream: av.video.stream.VideoStream = container.streams.video[0]
+        time_base: Fraction | None = in_stream.time_base
+        if time_base is None:
+            raise ValueError("Input video stream has no time_base; cannot derive frame timestamps.")
+        ns_scale: Fraction = Fraction(1_000_000_000, 1)
+        for packet in container.demux(in_stream):
+            if packet.pts is None:
+                continue
+            timestamps_ns.append(round(packet.pts * time_base * ns_scale))
+    finally:
+        container.close()
+    if not timestamps_ns:
+        raise RuntimeError("PyAV could not derive any frame timestamps from the video stream.")
+    return np.sort(np.asarray(timestamps_ns, dtype=np.int64))
 
 
 def _log_video_stream(

--- a/tests/test_epfl_smart_kitchen.py
+++ b/tests/test_epfl_smart_kitchen.py
@@ -1,0 +1,674 @@
+import csv
+import json
+from pathlib import Path
+
+import av
+import numpy as np
+import pytest
+import rerun as rr
+from jaxtyping import UInt8
+from numpy import ndarray
+
+from simplecv.apis.view_exoego import VisualizeConfig, visualize_exo_ego
+from simplecv.configs.exoego_dataset_configs import dataset_defaults
+from simplecv.data.exoego import epfl_smart_kitchen as epfl_module
+from simplecv.data.exoego.epfl_smart_kitchen import (
+    EpflSmartKitchenConfig,
+    EpflSmartKitchenSequence,
+    _parse_numeric_cell,
+    load_hololens_world_to_camera_poses,
+    video_path_for_camera,
+)
+from simplecv.rerun_log_utils import RerunTyroConfig
+from simplecv.rrd_query_utils import RRDQuerySession, first_valid_value
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
+
+
+def _frame_pixels(frame_idx: int) -> UInt8[ndarray, "h w 3"]:
+    pixels: UInt8[ndarray, "h w 3"] = np.empty((32, 32, 3), dtype=np.uint8)
+    pixels[..., 0] = np.uint8(frame_idx * 30)
+    pixels[..., 1] = np.uint8(40 + frame_idx * 20)
+    pixels[..., 2] = np.uint8(80 + frame_idx * 10)
+    return pixels
+
+
+def _write_synthetic_mp4(path: Path, num_frames: int = 3) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    container: av.container.OutputContainer = av.open(str(path), mode="w")
+    stream: av.video.stream.VideoStream = container.add_stream(
+        "h264", rate=30, options={"preset": "ultrafast", "crf": "0"}
+    )
+    stream.width = 32
+    stream.height = 32
+    stream.pix_fmt = "yuv420p"
+    stream.max_b_frames = 0
+    for frame_idx in range(num_frames):
+        frame: av.VideoFrame = av.VideoFrame.from_ndarray(_frame_pixels(frame_idx), format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+
+def _write_minimal_public_release(root: Path) -> None:
+    session_dir: Path = root / "Public_release_videos" / "train" / "YH2002" / "2023_12_04_10_15_23"
+    videos_dir: Path = session_dir / "videos"
+    meta_dir: Path = session_dir / "meta_data"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    _write_synthetic_mp4(videos_dir / "hololens.mp4")
+    _write_synthetic_mp4(videos_dir / "output0.mp4")
+
+    camera_matrix: dict[str, dict[str, list[list[float]] | list[float] | int]] = {
+        "hololens": {
+            "K": [[100.0, 0.0, 16.0], [0.0, 100.0, 16.0], [0.0, 0.0, 1.0]],
+            "dist": [],
+            "width": 32,
+            "height": 32,
+        },
+        "output0": {
+            "world2cam": [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+            "K": [[100.0, 0.0, 16.0], [0.0, 100.0, 16.0], [0.0, 0.0, 1.0]],
+            "dist": [],
+            "width": 32,
+            "height": 32,
+        },
+    }
+    (meta_dir / "camera_matrix.json").write_text(json.dumps(camera_matrix))
+    world2holo: list[list[float]] = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    with (meta_dir / "holo_data_wpose.csv").open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["world2holo"])
+        writer.writeheader()
+        for _ in range(3):
+            writer.writerow({"world2holo": json.dumps(world2holo)})
+    (meta_dir / "timestamps.txt").write_text("1000\n34333\n67666\n")
+
+    pose_dir: Path = root / "Public_release_pose" / "train" / "YH2002" / "2023_12_04_10_15_23" / "pose_3d"
+    pose_dir.mkdir(parents=True, exist_ok=True)
+    body_kpts: list[list[float]] = [[float(idx), float(idx + 1), float(idx + 2)] for idx in range(17)]
+    hand_kpts: list[list[float]] = [[float(idx), float(idx + 1), float(idx + 2)] for idx in range(42)]
+    body_conf: list[float] = [1.0] * 17
+    hand_conf: list[float] = [1.0] * 42
+    left_shape: list[float] = [float(idx) * 0.01 for idx in range(10)]
+    right_shape: list[float] = [value + 1e-5 for value in left_shape]
+    left_pose: list[float] = [0.01] * 48
+    right_pose: list[float] = [0.02] * 48
+    with (pose_dir / "pose3d_smpl.csv").open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["kp3ds", "kp3ds_conf", "l2_dist"])
+        writer.writeheader()
+        for _ in range(3):
+            writer.writerow(
+                {
+                    "kp3ds": json.dumps(body_kpts),
+                    "kp3ds_conf": json.dumps(body_conf),
+                    "l2_dist": "0.01",
+                }
+            )
+    with (pose_dir / "pose3d_mano.csv").open("w", newline="") as file:
+        writer = csv.DictWriter(
+            file,
+            fieldnames=[
+                "kp3ds",
+                "kp3ds_conf",
+                "l2_dist_left",
+                "l2_dist_right",
+                "left_poses",
+                "right_poses",
+                "left_Rh",
+                "right_Rh",
+                "left_Th",
+                "right_Th",
+                "left_shapes",
+                "right_shapes",
+            ],
+        )
+        writer.writeheader()
+        for _ in range(3):
+            writer.writerow(
+                {
+                    "kp3ds": json.dumps(hand_kpts),
+                    "kp3ds_conf": json.dumps(hand_conf),
+                    "l2_dist_left": "0.01",
+                    "l2_dist_right": "0.01",
+                    "left_poses": json.dumps(left_pose),
+                    "right_poses": json.dumps(right_pose),
+                    "left_Rh": json.dumps([0.0, 0.0, 0.0]),
+                    "right_Rh": json.dumps([0.0, 0.0, 0.0]),
+                    "left_Th": json.dumps([0.1, 0.2, 0.3]),
+                    "right_Th": json.dumps([0.4, 0.5, 0.6]),
+                    "left_shapes": json.dumps(left_shape),
+                    "right_shapes": json.dumps(right_shape),
+                }
+            )
+
+
+def test_epfl_smart_kitchen_sequence_identity_includes_split_participant_and_session() -> None:
+    cfg = EpflSmartKitchenConfig(
+        root_directory=Path("data/epfl-smart-kitchen/sample"),
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+
+    identity = EpflSmartKitchenSequence.sequence_identity_for_config(cfg)
+
+    assert identity.dataset == "epfl-smart-kitchen"
+    assert identity.sequence_key == "train/YH2002/2023_12_04_10_15_23"
+    assert identity.recording_id == "epfl-smart-kitchen__train__YH2002__2023_12_04_10_15_23"
+    assert identity.rrd_path(Path("/tmp/catalog")) == Path(
+        "/tmp/catalog/epfl-smart-kitchen/train/YH2002/2023_12_04_10_15_23.rrd"
+    )
+
+
+def test_epfl_smart_kitchen_is_registered_for_generic_exoego_viewer() -> None:
+    assert isinstance(dataset_defaults["epfl-smart-kitchen"], EpflSmartKitchenConfig)
+
+
+def test_epfl_smart_kitchen_default_root_uses_av1_mirror() -> None:
+    cfg = EpflSmartKitchenConfig()
+
+    assert cfg.root_directory == Path("/mnt/8tb/data/epfl-smart-kitchen-av1")
+
+
+def test_epfl_smart_kitchen_ignores_generated_hololens_sidecar_when_present(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+    sidecar_path: Path = (
+        tmp_path
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "videos"
+        / "hololens.rerun_h264.mp4"
+    )
+    sidecar_path.write_bytes(b"sidecar")
+
+    assert video_path_for_camera(cfg, "hololens").name == "hololens.mp4"
+    assert video_path_for_camera(cfg, "output0").name == "output0.mp4"
+
+
+def test_epfl_smart_kitchen_uses_compact_image_planes(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=False,
+    )
+    sequence = EpflSmartKitchenSequence(cfg)
+
+    assert sequence.ego_sequence is not None
+    assert sequence.exo_sequence is not None
+    assert sequence.ego_sequence.image_plane_distance == 0.1
+    assert sequence.exo_sequence.image_plane_distance == 0.25
+
+
+def test_epfl_smart_kitchen_sample_download_task_matches_hocap_style() -> None:
+    pyproject_text: str = (PROJECT_ROOT / "pyproject.toml").read_text()
+
+    assert "[tool.pixi.tasks._download-epfl-smart-kitchen-sample]" in pyproject_text
+    assert "pablovela5620/epfl-smart-kitchen-sample" in pyproject_text
+    assert "data/epfl-smart-kitchen/sample.zip" in pyproject_text
+    assert "data/epfl-smart-kitchen/sample" in pyproject_text
+
+
+def test_epfl_smart_kitchen_counts_train_and_test_sessions(tmp_path: Path) -> None:
+    (tmp_path / "Public_release_pose" / "train" / "YH2002" / "2023_12_04_10_15_23" / "pose_3d").mkdir(
+        parents=True
+    )
+    (tmp_path / "Public_release_videos" / "train" / "YH2002" / "2023_12_04_10_15_23").mkdir(parents=True)
+    (tmp_path / "Public_release_pose" / "test" / "YH2003" / "2023_12_05_11_16_24" / "pose_3d").mkdir(
+        parents=True
+    )
+    (tmp_path / "Public_release_videos" / "test" / "YH2003" / "2023_12_05_11_16_24").mkdir(parents=True)
+    (tmp_path / "Public_release_pose" / "test" / "YH2004" / "pose_only_session" / "pose_3d").mkdir(parents=True)
+    cfg = EpflSmartKitchenConfig(root_directory=tmp_path)
+
+    assert EpflSmartKitchenSequence.num_sequences_for_config(cfg) == 2
+
+
+def test_epfl_smart_kitchen_numeric_parser_preserves_large_values_and_non_finites() -> None:
+    parsed = _parse_numeric_cell("[100001.0, NaN, -Infinity, inf]")
+
+    assert float(parsed[0]) == pytest.approx(100001.0)
+    assert np.isnan(parsed[1])
+    assert np.isneginf(parsed[2])
+    assert np.isposinf(parsed[3])
+
+
+def test_epfl_smart_kitchen_sequence_loads_no_label_ego_and_exo_streams(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=False,
+    )
+
+    sequence = EpflSmartKitchenSequence(cfg)
+    sample = sequence[0]
+
+    assert sequence.canonical_stream_name in {"ego/hololens", "exo/output0"}
+    assert sample.labels is None
+    assert sample.ego_cam_params_list is not None
+    assert sample.exo_cam_params_list is not None
+    assert sample.ego_cam_params_list[0].name == "hololens"
+    assert sample.exo_cam_params_list[0].name == "output0"
+    np.testing.assert_array_equal(
+        sequence.stream_timestamps_ns["ego/hololens"],
+        np.array([0, 33333000, 66666000], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        sequence.stream_timestamps_ns["exo/output0"],
+        np.array([0, 33333000, 66666000], dtype=np.int64),
+    )
+
+
+def test_epfl_smart_kitchen_hololens_video_dimensions_are_loaded_once(tmp_path: Path, monkeypatch) -> None:
+    _write_minimal_public_release(tmp_path)
+    camera_matrix_path: Path = (
+        tmp_path
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "meta_data"
+        / "camera_matrix.json"
+    )
+    camera_matrix: dict[str, dict] = json.loads(camera_matrix_path.read_text())
+    del camera_matrix["hololens"]["width"]
+    del camera_matrix["hololens"]["height"]
+    camera_matrix_path.write_text(json.dumps(camera_matrix))
+    calls: list[Path] = []
+
+    def fake_video_size(video_path: Path) -> tuple[int, int]:
+        calls.append(video_path)
+        return 32, 32
+
+    monkeypatch.setattr(epfl_module, "_video_size", fake_video_size)
+    from simplecv.data.ego.epfl_smart_kitchen_ego import EpflSmartKitchenEgoSequence
+
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+
+    ego_sequence = EpflSmartKitchenEgoSequence(cfg)
+
+    assert len(ego_sequence.ego_cam_dict["hololens"]) == 3
+    assert calls == [video_path_for_camera(cfg, "hololens")]
+
+
+def test_epfl_smart_kitchen_hololens_pose_loader_carries_previous_pose_for_empty_tracking_rows(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+    holo_path: Path = (
+        tmp_path
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "meta_data"
+        / "holo_data_wpose.csv"
+    )
+    first_pose: list[list[float]] = [
+        [1.0, 0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 2.0],
+        [0.0, 0.0, 1.0, 3.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    last_pose: list[list[float]] = [
+        [1.0, 0.0, 0.0, 4.0],
+        [0.0, 1.0, 0.0, 5.0],
+        [0.0, 0.0, 1.0, 6.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    with holo_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["world2holo"])
+        writer.writeheader()
+        writer.writerow({"world2holo": json.dumps(first_pose)})
+        writer.writerow({"world2holo": "[]"})
+        writer.writerow({"world2holo": json.dumps(last_pose)})
+
+    with pytest.warns(UserWarning, match="missing 1 HoloLens world2holo"):
+        poses = load_hololens_world_to_camera_poses(cfg)
+
+    assert len(poses) == 3
+    np.testing.assert_allclose(poses[0], np.array(first_pose, dtype=np.float32))
+    np.testing.assert_allclose(poses[1], np.array(first_pose, dtype=np.float32))
+    np.testing.assert_allclose(poses[2], np.array(last_pose, dtype=np.float32))
+
+
+def test_epfl_smart_kitchen_hololens_pose_loader_warns_when_leading_rows_use_first_valid_pose(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+    holo_path: Path = (
+        tmp_path
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "meta_data"
+        / "holo_data_wpose.csv"
+    )
+    first_valid_pose: list[list[float]] = [
+        [1.0, 0.0, 0.0, 7.0],
+        [0.0, 1.0, 0.0, 8.0],
+        [0.0, 0.0, 1.0, 9.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    with holo_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["world2holo"])
+        writer.writeheader()
+        writer.writerow({"world2holo": "[]"})
+        writer.writerow({"world2holo": json.dumps(first_valid_pose)})
+
+    with pytest.warns(UserWarning, match="first valid pose for leading gaps"):
+        poses = load_hololens_world_to_camera_poses(cfg)
+
+    assert len(poses) == 2
+    np.testing.assert_allclose(poses[0], np.array(first_valid_pose, dtype=np.float32))
+    np.testing.assert_allclose(poses[1], np.array(first_valid_pose, dtype=np.float32))
+
+
+def test_epfl_smart_kitchen_sequence_loads_coco133_labels_and_mano_stack(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=True,
+    )
+
+    sequence = EpflSmartKitchenSequence(cfg)
+    labels = sequence.exoego_labels
+
+    assert labels is not None
+    assert labels.xyzc_stack.shape == (3, 133, 4)
+    np.testing.assert_array_equal(labels.timestamps_ns, np.array([0, 33333000, 66666000], dtype=np.int64))
+    np.testing.assert_allclose(labels.xyzc_stack[0, 0, :3], np.array([0.0, 1.0, 2.0], dtype=np.float32))
+    np.testing.assert_allclose(labels.xyzc_stack[0, 91, :3], np.array([0.0, 1.0, 2.0], dtype=np.float32))
+    np.testing.assert_allclose(labels.xyzc_stack[0, 112, :3], np.array([21.0, 22.0, 23.0], dtype=np.float32))
+    assert float(labels.xyzc_stack[0, 91, 3]) == 1.0
+    assert float(labels.xyzc_stack[0, 112, 3]) == 1.0
+
+    assert labels.mano_stack is not None
+    assert labels.mano_stack.use_pca is False
+    assert labels.mano_stack.so3.shape == (3, 2, 48)
+    assert labels.mano_stack.trans.shape == (3, 2, 3)
+    np.testing.assert_allclose(labels.mano_stack.betas, np.array([float(idx) * 0.01 for idx in range(10)]))
+    np.testing.assert_allclose(labels.mano_stack.so3[0, 0], np.array([0.02] * 48, dtype=np.float32))
+    np.testing.assert_allclose(labels.mano_stack.so3[0, 1], np.array([0.01] * 48, dtype=np.float32))
+
+
+def test_epfl_smart_kitchen_rejects_short_mano_pose_vectors_instead_of_padding_pca(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_public_release(tmp_path)
+    hand_path: Path = (
+        tmp_path
+        / "Public_release_pose"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "pose_3d"
+        / "pose3d_mano.csv"
+    )
+    with hand_path.open(newline="") as file:
+        reader = csv.DictReader(file)
+        rows: list[dict[str, str]] = [dict(row) for row in reader]
+        fieldnames: list[str] = list(reader.fieldnames or [])
+    rows[0]["left_poses"] = json.dumps([0.1] * 12)
+    with hand_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=True,
+    )
+
+    with pytest.raises(ValueError, match="looks like PCA coefficients"):
+        EpflSmartKitchenSequence(cfg)
+
+
+def test_epfl_smart_kitchen_ego_sequence_warns_when_reusing_final_pose(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    holo_path: Path = (
+        tmp_path
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "meta_data"
+        / "holo_data_wpose.csv"
+    )
+    with holo_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["world2holo"])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "world2holo": json.dumps(
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]
+                )
+            }
+        )
+        writer.writerow(
+            {
+                "world2holo": json.dumps(
+                    [[1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 0.0, 2.0], [0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 0.0, 1.0]]
+                )
+            }
+        )
+    from simplecv.data.ego.epfl_smart_kitchen_ego import EpflSmartKitchenEgoSequence
+
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+    ego_sequence = EpflSmartKitchenEgoSequence(cfg)
+
+    with pytest.warns(UserWarning, match="reusing the final pose"):
+        ego_sequence[2]
+
+
+def test_epfl_smart_kitchen_visualized_rrd_contains_video_labels_and_mano(tmp_path: Path) -> None:
+    if not (PROJECT_ROOT / "simplecv" / "data" / "MANO_RIGHT.pkl").exists() or not (
+        PROJECT_ROOT / "simplecv" / "data" / "MANO_LEFT.pkl"
+    ).exists():
+        pytest.skip("MANO model files are not available")
+
+    _write_minimal_public_release(tmp_path)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=True,
+    )
+    sequence = EpflSmartKitchenSequence(cfg)
+    rrd_path: Path = tmp_path / "epfl-mini.rrd"
+    viz_config = VisualizeConfig(
+        rr_config=RerunTyroConfig(
+            application_id="test-epfl-visualize",
+            recording_id="test-epfl-visualize",
+            save=rrd_path,
+        ),
+        dataset=cfg,
+        log_exo=True,
+        log_ego=True,
+        log_labels=True,
+        log_mano=True,
+    )
+    rec: rr.RecordingStream = viz_config.rr_config.rec_stream
+
+    visualize_exo_ego(sequence, viz_config)
+    rec.flush(timeout_sec=60.0)
+
+    query_session = RRDQuerySession(rrd_path)
+    try:
+        column_names: list[str] = query_session._dataset_view("/**").arrow_schema().names
+        assert "/world/gt/mano/right/mesh:Mesh3D:vertex_positions" in column_names
+        assert "/world/gt/mano/left/mesh:Mesh3D:vertex_positions" in column_names
+        assert "/world/gt/mano/coco133_xyz:Points3D:positions" in column_names
+        assert "/world/ego/hololens/pinhole/video:VideoStream:codec" in column_names
+        assert "/world/exo/output0/pinhole/video:VideoStream:codec" in column_names
+
+        ego_plane_table = query_session.read_arrow(
+            contents="/**",
+            selectors=["/world/ego/hololens/pinhole:Pinhole:image_plane_distance"],
+            index=None,
+        )
+        exo_plane_table = query_session.read_arrow(
+            contents="/**",
+            selectors=["/world/exo/output0/pinhole:Pinhole:image_plane_distance"],
+            index=None,
+        )
+        ego_plane = first_valid_value(ego_plane_table["/world/ego/hololens/pinhole:Pinhole:image_plane_distance"])
+        exo_plane = first_valid_value(exo_plane_table["/world/exo/output0/pinhole:Pinhole:image_plane_distance"])
+        assert float(ego_plane[0]) == pytest.approx(0.1)
+        assert float(exo_plane[0]) == pytest.approx(0.25)
+    finally:
+        query_session.close()
+
+
+def test_epfl_smart_kitchen_empty_hand_l2_cells_do_not_drop_keypoints(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    hand_path: Path = (
+        tmp_path
+        / "Public_release_pose"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "pose_3d"
+        / "pose3d_mano.csv"
+    )
+    with hand_path.open(newline="") as file:
+        reader = csv.DictReader(file)
+        rows: list[dict[str, str]] = [dict(row) for row in reader]
+        fieldnames: list[str] = list(reader.fieldnames or [])
+    rows[0]["l2_dist_left"] = ""
+    rows[0]["l2_dist_right"] = ""
+    with hand_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=True,
+    )
+
+    with pytest.warns(UserWarning, match="empty EPFL hand l2 distance values"):
+        sequence = EpflSmartKitchenSequence(cfg)
+    labels = sequence.exoego_labels
+
+    assert labels is not None
+    assert float(labels.xyzc_stack[0, 91, 3]) == 1.0
+    assert float(labels.xyzc_stack[0, 112, 3]) == 1.0
+
+
+def test_epfl_smart_kitchen_empty_body_l2_cells_do_not_drop_keypoints(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    body_path: Path = (
+        tmp_path
+        / "Public_release_pose"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "pose_3d"
+        / "pose3d_smpl.csv"
+    )
+    with body_path.open(newline="") as file:
+        reader = csv.DictReader(file)
+        rows: list[dict[str, str]] = [dict(row) for row in reader]
+        fieldnames: list[str] = list(reader.fieldnames or [])
+    rows[0]["l2_dist"] = ""
+    with body_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=True,
+    )
+
+    with pytest.warns(UserWarning, match="empty EPFL body l2 distance values"):
+        sequence = EpflSmartKitchenSequence(cfg)
+    labels = sequence.exoego_labels
+
+    assert labels is not None
+    assert float(labels.xyzc_stack[0, 0, 3]) == 1.0
+
+
+def test_epfl_smart_kitchen_label_load_fails_on_timestamp_count_mismatch(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    timestamps_path: Path = (
+        tmp_path
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "meta_data"
+        / "timestamps.txt"
+    )
+    timestamps_path.write_text("1000\n34333\n")
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+        exo_camera_names=("output0",),
+        load_labels=True,
+    )
+
+    with pytest.raises(ValueError, match="label frame count must match RGB timestamp count"):
+        EpflSmartKitchenSequence(cfg)

--- a/tests/test_exoego_catalog.py
+++ b/tests/test_exoego_catalog.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+from dataclasses import fields
 from pathlib import Path
 from typing import Any
 
 import pyarrow as pa
 import pytest
+import tomllib
 
+import simplecv.apis.exoego_forge_catalog as catalog_module
 from simplecv.apis.exoego_forge_catalog import (
     CATALOG_CAMERA_NAMES,
     DEFAULT_CATALOG_DATASETS,
@@ -31,15 +34,19 @@ from simplecv.apis.exoego_forge_catalog import (
     build_table_card_blueprint,
     discover_rrd_paths,
     discover_rrd_uris,
+    mount_catalog,
     table_name_for_dataset,
 )
 from simplecv.data.exoego.aria_gen2_pilot import AriaGen2PilotConfig, AriaGen2PilotSequence
 from simplecv.data.exoego.assembly101 import Assembly101Config, Assembly101Sequence
 from simplecv.data.exoego.ego_dex import EgoDexConfig, EgoDexSequence
+from simplecv.data.exoego.epfl_smart_kitchen import EpflSmartKitchenConfig, EpflSmartKitchenSequence
 from simplecv.data.exoego.hocap import HocapConfig, HocapSequence
 from simplecv.data.exoego.hot3d import Hot3dConfig, Hot3dSequence
 from simplecv.data.exoego.sequence_identity import SequenceIdentity
 from simplecv.data.exoego.umetrack import UmeTrackConfig, UmeTrackSequence
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
 
 
 def test_sequence_identity_paths_and_recording_id() -> None:
@@ -118,6 +125,18 @@ def test_sequence_identity_rejects_recording_id_separator(
             "test/add_remove_lid/episode_0003",
             "ego-dex__test__add_remove_lid__episode_0003",
         ),
+        (
+            EpflSmartKitchenSequence.sequence_identity_for_config(
+                EpflSmartKitchenConfig(
+                    split="train",
+                    participant_id="YH2002",
+                    session_name="2023_12_04_10_15_23",
+                )
+            ),
+            "epfl-smart-kitchen",
+            "train/YH2002/2023_12_04_10_15_23",
+            "epfl-smart-kitchen__train__YH2002__2023_12_04_10_15_23",
+        ),
     ],
 )
 def test_dataset_sequence_identity_for_config(
@@ -172,11 +191,23 @@ def test_discover_rrd_paths_raises_when_no_requested_dataset_has_rrds(tmp_path: 
 def test_catalog_config_defaults_to_general_catalog_index() -> None:
     config: CatalogConfig = CatalogConfig()
 
+    assert [field.name for field in fields(CatalogConfig)] == [
+        "rrd_root",
+        "datasets",
+        "port",
+        "application_id",
+        "optimize_for_catalog",
+        "catalog_rrd_cache_dir",
+        "optimize_datasets",
+        "open_browser",
+        "web_port",
+    ]
     assert config.rrd_root == Path("data/exoego-forge-catalog")
     assert config.datasets == DEFAULT_CATALOG_DATASETS
     assert config.datasets == (
         "aria-gen2",
         "assembly101",
+        "epfl-smart-kitchen",
         "hocap",
         "hot3d-aria",
         "hot3d-quest3",
@@ -189,11 +220,23 @@ def test_catalog_config_defaults_to_general_catalog_index() -> None:
     assert config.catalog_rrd_cache_dir == DEFAULT_CATALOG_RRD_CACHE_DIR
 
 
+def test_pixi_catalog_task_skips_preoptimization_for_interactive_startup() -> None:
+    pyproject_text: str = (PROJECT_ROOT / "pyproject.toml").read_text()
+    pyproject_data: dict[str, Any] = tomllib.loads(pyproject_text)
+    catalog_task: dict[str, Any] = pyproject_data["tool"]["pixi"]["tasks"]["catalog"]
+    catalog_cmd: str = catalog_task["cmd"]
+
+    assert "[tool.pixi.tasks.catalog]" in pyproject_text
+    assert catalog_cmd == "python tools/catalog.py --rrd-root /mnt/8tb/data/exoego-forge-catalog --no-optimize-for-catalog"
+    assert "pre-optimizes missing RRD cache copies before Rerun registration" in pyproject_text
+
+
 @pytest.mark.parametrize(
     ("dataset_name", "table_name"),
     [
         ("aria-gen2", "aria_gen2_table"),
         ("assembly101", "assembly101_table"),
+        ("epfl-smart-kitchen", "epfl_smart_kitchen_table"),
         ("hocap", "hocap_table"),
         ("hot3d-aria", "hot3d_aria_table"),
         ("hot3d-quest3", "hot3d_quest3_table"),
@@ -280,6 +323,139 @@ def test_build_rrd_index_rows_from_paths(tmp_path: Path) -> None:
     assert rows[0].recording_uri == str(second_rrd.resolve())
     assert rows[1].path == str(first_rrd.resolve())
     assert [row.size_bytes for row in rows] == [len(b"not a real rrd"), len(b"not a real rrd")]
+
+
+def test_mount_catalog_python_server_preserves_recursive_file_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rrd_root: Path = tmp_path / "rrds"
+    first_rrd: Path = rrd_root / "assembly101" / "all" / "seq_01.rrd"
+    second_rrd: Path = rrd_root / "assembly101" / "all" / "nested" / "seq_02.rrd"
+    for path in (first_rrd, second_rrd):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"not a real rrd")
+    captured_datasets: dict[str, list[Path]] = {}
+
+    class _FakeClient:
+        def get_dataset(self, dataset_name: str) -> _FakeBlueprintDatasetEntry:
+            assert dataset_name == "assembly101"
+            return _FakeBlueprintDatasetEntry()
+
+    class _FakeRerunServer:
+        def __init__(self, *, datasets: dict[str, list[Path]], port: int | None) -> None:
+            assert port is None
+            captured_datasets.update(datasets)
+
+        def url(self) -> str:
+            return "rerun+http://127.0.0.1:9999"
+
+        def client(self) -> _FakeClient:
+            return _FakeClient()
+
+        def is_running(self) -> bool:
+            return False
+
+        def shutdown(self) -> None:
+            pass
+
+        def __enter__(self) -> _FakeRerunServer:
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: Any | None,
+        ) -> None:
+            pass
+
+    monkeypatch.setattr(catalog_module.rr.server, "Server", _FakeRerunServer)
+    monkeypatch.setattr(catalog_module, "_register_default_dataset_blueprint", lambda *_args, **_kwargs: Path("noop.rbl"))
+
+    mount_catalog(
+        rrd_root,
+        datasets=("assembly101",),
+        optimize_for_catalog=False,
+        show_progress=False,
+    )
+
+    assert captured_datasets == {
+        "assembly101": [
+            second_rrd.resolve(),
+            first_rrd.resolve(),
+        ]
+    }
+
+
+def test_catalog_main_shutdowns_server_directly_on_keyboard_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rrd_root: Path = tmp_path / "rrds"
+    source_rrd: Path = rrd_root / "assembly101" / "all" / "seq_01.rrd"
+    source_rrd.parent.mkdir(parents=True, exist_ok=True)
+    source_rrd.write_bytes(b"not a real rrd")
+    shutdown_calls: list[str] = []
+
+    class _FakeTable:
+        id: str = "table_id"
+
+    class _FakeClient:
+        def get_dataset(self, dataset_name: str) -> _FakeBlueprintDatasetEntry:
+            assert dataset_name == "assembly101"
+            return _FakeBlueprintDatasetEntry()
+
+    class _FakeServer:
+        def url(self) -> str:
+            return "rerun+http://127.0.0.1:9988"
+
+        def client(self) -> _FakeClient:
+            return _FakeClient()
+
+        def shutdown(self) -> None:
+            shutdown_calls.append("shutdown")
+
+        def __enter__(self) -> _FakeServer:
+            raise AssertionError("catalog main should not rely on Rerun Server.__enter__")
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: Any | None,
+        ) -> None:
+            raise AssertionError("catalog main should not rely on Rerun Server.__exit__")
+
+    fake_server = _FakeServer()
+
+    monkeypatch.setattr(catalog_module, "mount_catalog", lambda *_args, **_kwargs: fake_server)
+    monkeypatch.setattr(
+        catalog_module,
+        "build_rrd_index_rows_from_dataset",
+        lambda *_args, **_kwargs: [
+            RRDIndexRow(
+                id=0,
+                dataset="assembly101",
+                sequence_key="all/seq_01",
+                recording_uri="rerun+http://127.0.0.1:9988/dataset/assembly101?segment_id=assembly101__all__seq_01",
+                path=str(source_rrd),
+                size_bytes=source_rrd.stat().st_size,
+            )
+        ],
+    )
+    monkeypatch.setattr(catalog_module, "create_rrd_index_table", lambda *_args, **_kwargs: _FakeTable())
+    monkeypatch.setattr(catalog_module.time, "sleep", lambda _seconds: (_ for _ in ()).throw(KeyboardInterrupt))
+
+    catalog_module.main(
+        CatalogConfig(
+            rrd_root=rrd_root,
+            datasets=("assembly101",),
+            optimize_for_catalog=False,
+        )
+    )
+
+    assert shutdown_calls == ["shutdown"]
 
 
 def test_register_default_dataset_blueprint_registers_full_segment_blueprint() -> None:
@@ -464,6 +640,23 @@ def test_table_preview_camera_falls_back_when_override_camera_is_missing() -> No
 def test_table_preview_window_constants_cover_first_ten_seconds() -> None:
     assert TABLE_CARD_PREVIEW_START_SECONDS == 0.0
     assert TABLE_CARD_PREVIEW_END_SECONDS == 10.0
+
+
+def test_epfl_smart_kitchen_catalog_uses_hololens_and_all_nine_exo_cameras() -> None:
+    camera_names: dict[str, tuple[str, ...]] = CATALOG_CAMERA_NAMES["epfl-smart-kitchen"]
+
+    assert camera_names["ego"] == ("hololens",)
+    assert camera_names["exo"] == (
+        "output0",
+        "Aoutput0",
+        "Aoutput1",
+        "Aoutput2",
+        "Aoutput3",
+        "Boutput0",
+        "Boutput1",
+        "Boutput2",
+        "Boutput3",
+    )
 
 
 def test_video_exclusion_queries_remove_hocap_videos_from_3d_view() -> None:

--- a/tests/test_log_video.py
+++ b/tests/test_log_video.py
@@ -60,6 +60,27 @@ def synthetic_h264_mp4(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return out_path
 
 
+@pytest.fixture(scope="session")
+def synthetic_mpeg4_mp4(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Deterministic MPEG-4 Part 2 MP4, matching EPFL HoloLens codec behavior."""
+    out_path: Path = tmp_path_factory.mktemp("log_video") / "synthetic-mpeg4.mp4"
+    container: av.container.OutputContainer = av.open(str(out_path), mode="w")
+    stream: av.video.stream.VideoStream = container.add_stream("mpeg4", rate=_FPS)
+    stream.width = _WIDTH
+    stream.height = _HEIGHT
+    stream.pix_fmt = "yuv420p"
+    stream.max_b_frames = 0
+
+    for i in range(_FRAME_COUNT):
+        frame: av.VideoFrame = av.VideoFrame.from_ndarray(_frame_pixels(i), format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+    return out_path
+
+
 def _decode_mp4(source: Path | bytes) -> list[UInt8[ndarray, "h w 3"]]:
     handle: io.BytesIO | str = io.BytesIO(source) if isinstance(source, bytes) else str(source)
     container: av.container.InputContainer = av.open(handle, mode="r")
@@ -168,6 +189,27 @@ def test_log_video_timestamps_match(synthetic_h264_mp4: Path, tmp_path: Path) ->
     assert len(ts_asset) == _FRAME_COUNT
     assert len(ts_stream) == _FRAME_COUNT
     np.testing.assert_array_equal(np.sort(ts_asset), np.sort(ts_stream))
+
+
+def test_log_video_stream_requires_supported_codec(
+    synthetic_mpeg4_mp4: Path,
+    tmp_path: Path,
+) -> None:
+    rec: rr.RecordingStream = rr.RecordingStream(
+        application_id="test-log-video-unsupported-codec",
+        recording_id="unsupported-codec",
+    )
+    rec.save(str(tmp_path / "unsupported.rrd"))
+    entity: str = "/video"
+
+    with pytest.raises(ValueError, match="not supported by rr.VideoStream"):
+        log_video(
+            synthetic_mpeg4_mp4,
+            Path(entity),
+            timeline="video_time",
+            method="video_stream",
+            recording=rec,
+        )
 
 
 @pytest.mark.parametrize("video_fixture", ["synthetic", "hocap"])

--- a/tests/test_preprocess_epfl_smart_kitchen.py
+++ b/tests/test_preprocess_epfl_smart_kitchen.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import pytest
+
+from simplecv.apis.preprocess_epfl_smart_kitchen import (
+    PreprocessConfig,
+    VideoProbe,
+    _validate_target_probe,
+    build_mirror_plan,
+    dataset_card_text,
+)
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("data")
+
+
+def test_epfl_av1_mirror_plan_preserves_layout_and_excludes_generated_outputs(tmp_path: Path) -> None:
+    source_root: Path = tmp_path / "source"
+    target_root: Path = tmp_path / "target"
+    session_root: Path = source_root / "Public_release_videos" / "train" / "YH2002" / "2023_12_04_10_15_23"
+    _touch(session_root / "videos" / "hololens.mp4")
+    _touch(session_root / "videos" / "output0.mp4")
+    _touch(session_root / "videos_depth" / "hololens_depth.mp4")
+    _touch(session_root / "videos" / "hololens.rerun_h264.mp4")
+    _touch(source_root / "Public_release_videos.zip")
+    _touch(
+        source_root
+        / "Public_release_videos"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23-av1-test"
+        / "videos"
+        / "hololens.mp4"
+    )
+    _touch(session_root / "meta_data" / "camera_matrix.json")
+    _touch(
+        source_root
+        / "Public_release_pose"
+        / "train"
+        / "YH2002"
+        / "2023_12_04_10_15_23"
+        / "pose_3d"
+        / "pose3d_mano.csv"
+    )
+
+    plan = build_mirror_plan(source_root=source_root, target_root=target_root)
+
+    video_rels: set[str] = {job.relative_path.as_posix() for job in plan.video_jobs}
+    copy_rels: set[str] = {job.relative_path.as_posix() for job in plan.copy_jobs}
+
+    assert video_rels == {
+        "Public_release_videos/train/YH2002/2023_12_04_10_15_23/videos/hololens.mp4",
+        "Public_release_videos/train/YH2002/2023_12_04_10_15_23/videos/output0.mp4",
+        "Public_release_videos/train/YH2002/2023_12_04_10_15_23/videos_depth/hololens_depth.mp4",
+    }
+    assert "Public_release_videos/train/YH2002/2023_12_04_10_15_23/videos/hololens.rerun_h264.mp4" not in video_rels
+    assert all("-av1-test" not in rel for rel in video_rels)
+    assert "Public_release_videos.zip" not in copy_rels
+    assert "Public_release_videos/train/YH2002/2023_12_04_10_15_23/meta_data/camera_matrix.json" in copy_rels
+    assert "Public_release_pose/train/YH2002/2023_12_04_10_15_23/pose_3d/pose3d_mano.csv" in copy_rels
+    assert all(not rel.endswith(".mp4") for rel in copy_rels)
+    assert all(job.target_path == target_root / job.relative_path for job in plan.video_jobs)
+
+
+def test_epfl_av1_dataset_card_has_requested_language() -> None:
+    card_text: str = dataset_card_text()
+
+    assert "license: cc-by-nc-4.0" in card_text
+    assert "AV1-transcoded SimpleCV-compatible mirror" in card_text
+    assert "Not endorsed by EPFL" not in card_text
+    assert "Unofficial AV1-transcoded" not in card_text
+    assert "not the official upstream release" not in card_text
+
+
+def test_epfl_av1_preprocess_task_is_registered() -> None:
+    pyproject_text: str = (PROJECT_ROOT / "pyproject.toml").read_text()
+
+    assert "[tool.pixi.tasks.preprocess-epfl-smart-kitchen]" in pyproject_text
+    assert "tools/preprocess_epfl_smart_kitchen.py" in pyproject_text
+
+
+def test_epfl_av1_nvenc_default_uses_single_worker() -> None:
+    config = PreprocessConfig()
+
+    assert config.num_workers == 1
+
+
+def test_epfl_av1_validate_target_probe_warns_on_frame_count_mismatch() -> None:
+    source_probe = VideoProbe(
+        path="/tmp/source.mp4",
+        codec_name="h264",
+        width=640,
+        height=480,
+        pix_fmt="yuv420p",
+        duration_sec=10.0,
+        frame_count=300,
+        size_bytes=100,
+    )
+    target_probe = VideoProbe(
+        path="/tmp/target.mp4",
+        codec_name="av1",
+        width=640,
+        height=480,
+        pix_fmt="yuv420p",
+        duration_sec=10.0,
+        frame_count=299,
+        size_bytes=50,
+    )
+
+    with pytest.warns(UserWarning, match="Target frame count does not match source"):
+        message = _validate_target_probe(
+            source_probe=source_probe,
+            target_probe=target_probe,
+            duration_tolerance_sec=0.25,
+        )
+
+    assert message == "frame_count_mismatch"

--- a/tools/preprocess_epfl_smart_kitchen.py
+++ b/tools/preprocess_epfl_smart_kitchen.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.preprocess_epfl_smart_kitchen import PreprocessConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PreprocessConfig, description="Build an AV1 EPFL-Smart-Kitchen mirror for SimpleCV."))


### PR DESCRIPTION
## Summary
- Add a first-class EPFL-Smart-Kitchen ExoEgo adapter with ego/exo loaders, calibration, timestamps, and MANO metadata support
- Register EPFL in the generic ExoEgo catalog and viewer paths alongside the existing datasets
- Add the EPFL preprocessing pipeline plus sample/full dataset validation tests
- Update project guidance, Pixi tasks, and dataset skills for the new workflow

## Testing
- Added focused unit and integration tests for EPFL parsing, catalog registration, preprocessing, and video logging behavior
- Verified the updated catalog path and shutdown flow with targeted pytest and Ruff checks